### PR TITLE
[BUGFIX] Majic3 Premiere ligne non standard

### DIFF
--- a/cadastre_import.py
+++ b/cadastre_import.py
@@ -414,6 +414,8 @@ class cadastreImport(QObject):
                         with open(fpath) as fin:
                             # Divide file into chuncks
                             for a in fin:
+                                if len( a ) < 4 :
+                                  continue
                                 depdir = a[0:3]
                                 break
                             depdirs[depdir] = True


### PR DESCRIPTION
Dans le cas ou les premières ne commencent pas par le code département et le
 numéro de direction, le plugin doit tester la ligne suivante. Il trouvera
 ainsi forcément un code département et un numéro de direction.