### PR TITLE
Import données cadastrales: ogr2ogr

### DIFF
--- a/cadastre_import.py
+++ b/cadastre_import.py
@@ -1309,6 +1309,10 @@ class cadastreImport(QObject):
                         self.dialog.schema
                     )
                 else:
+                    # qgis can connect to postgis DB without a specified host param connection, but ogr2ogr cannot
+                    if not host:
+                        host = "localhost"
+                        
                     pg_access = 'PG:host=%s port=%s dbname=%s active_schema=%s user=%s password=%s' % (
                         host,
                         port,


### PR DESCRIPTION
Sous qgis, se connecter à une base postgis locale n'oblige pas à définir le paramètre "host" dans les paramètres de connexion. 
En revanche, sous ogr2ogr, la commande n'aboutie pas si le paramètre host n'est pas spécifié.

Pour harmoniser, une substitution automatique dans le cas où host est vide pourrait aider.

Version qgis: 3.2.3-Bonn