### PR TITLE
Correction création couche Parcelles

### DIFF
--- a/scripts/plugin/edigeo_create_table_parcelle_info_simple.sql
+++ b/scripts/plugin/edigeo_create_table_parcelle_info_simple.sql
@@ -24,7 +24,7 @@ gp.lot AS lot,
 gp.geom AS geom
 FROM [PREFIXE]geo_parcelle gp
 INNER JOIN [PREFIXE]geo_commune c
-ON c.geo_commune = SUBSTRING(gp.geo_parcelle,1,10)
+ON c.geo_commune = SUBSTRING(gp.geo_parcelle,1,6)
 ;
 
 ALTER TABLE [PREFIXE]parcelle_info ADD CONSTRAINT parcelle_info_pk PRIMARY KEY (ogc_fid);


### PR DESCRIPTION
Mise à jour du fichier `edigeo_create_table_parcelle_info_simple.sql` pour corriger le problème de remplissage de la couche `parcelle_info` lorsqu'il n'y a pas de fichier MAJIC importé.