### PR TITLE
Update majic3_formatage_donnees.sql

### DIFF
--- a/scripts/plugin/2019/majic3_formatage_donnees.sql
+++ b/scripts/plugin/2019/majic3_formatage_donnees.sql
@@ -1,5 +1,5 @@
 -- Suppression de l'attribut vecexn qui disparait en 2019
-ALTER TABLE [PREFIXE]sufexoneration DROP COLUMN vecexn;
+ALTER TABLE [PREFIXE]sufexoneration DROP COLUMN IF EXISTS vecexn;
 
 -- FORMATAGE DONNEES : DEBUT
 BEGIN;


### PR DESCRIPTION
Correction: la commande de suppression de la colonne "vecexn" ne doit se faire que lorsque celle-ci existe encore, ce qui n'est pas le cas si on importe les données en plusieurs lots. La colonne étant supprimée lors de l'import d'un premier lot, celle-ci ne peut pas être supprimée un seconde fois pour l'import des lots suivants: cela provoquerait une erreur.