### PR TITLE
Compatibilité avec QGIS  > 3.10

### DIFF
--- a/cadastre/cadastre_common_base.py
+++ b/cadastre/cadastre_common_base.py
@@ -218,7 +218,13 @@ def getConnectorFromUri(connectionParams: Dict[str, str]) -> 'DBConnector':
                 connectionParams['password']
             )
 
-        connector = PostGisDBConnector(uri)
+        # we need a fake DBPlugin object
+        # with connetonName and providerName methods
+        obj = QObject()
+        obj.connectionName = lambda: 'fake'
+        obj.providerName = lambda: 'postgres'
+
+        connector = PostGisDBConnector(uri, obj)
 
     if connectionParams['dbType'] == 'spatialite':
         uri.setConnection('', '', connectionParams['dbname'], '', '')

--- a/cadastre/cadastre_common_base.py
+++ b/cadastre/cadastre_common_base.py
@@ -221,7 +221,7 @@ def getConnectorFromUri(connectionParams: Dict[str, str]) -> 'DBConnector':
 
         if Qgis.QGIS_VERSION_INT >= 31200:
             # we need a fake DBPlugin object
-            # with connetonName and providerName methods
+            # with connectionName and providerName methods
             obj = QObject()
             obj.connectionName = lambda: 'fake'
             obj.providerName = lambda: 'postgres'

--- a/cadastre/cadastre_common_base.py
+++ b/cadastre/cadastre_common_base.py
@@ -25,6 +25,7 @@ from typing import Dict, List, Any, Union
 from qgis.PyQt.QtCore import QObject
 
 from qgis.core import (
+    Qgis,
     QgsProject,
     QgsMapLayer,
     QgsMessageLog,
@@ -218,13 +219,16 @@ def getConnectorFromUri(connectionParams: Dict[str, str]) -> 'DBConnector':
                 connectionParams['password']
             )
 
-        # we need a fake DBPlugin object
-        # with connetonName and providerName methods
-        obj = QObject()
-        obj.connectionName = lambda: 'fake'
-        obj.providerName = lambda: 'postgres'
+        if Qgis.QGIS_VERSION_INT >= 31200:
+            # we need a fake DBPlugin object
+            # with connetonName and providerName methods
+            obj = QObject()
+            obj.connectionName = lambda: 'fake'
+            obj.providerName = lambda: 'postgres'
 
-        connector = PostGisDBConnector(uri, obj)
+            connector = PostGisDBConnector(uri, obj)
+        else:
+            connector = PostGisDBConnector(uri)
 
     if connectionParams['dbType'] == 'spatialite':
         uri.setConnection('', '', connectionParams['dbname'], '', '')

--- a/cadastre/cadastre_common_base.py
+++ b/cadastre/cadastre_common_base.py
@@ -22,6 +22,8 @@ from pathlib import Path
 
 from typing import Dict, List, Any, Union
 
+from qgis.PyQt.QtCore import QObject
+
 from qgis.core import (
     QgsProject,
     QgsMapLayer,
@@ -169,9 +171,7 @@ def fetchDataFromSqlQuery(connector: 'DBConnector',
             header = []
         if len(header) > 0:
             data = connector._fetchall(c)
-        rowCount = c.rowcount
-        if rowCount == -1:
-            rowCount = len(data)
+        rowCount = len(data)
 
     except BaseError as e:
         ok = False


### PR DESCRIPTION
* Ticket : #227

Ce fix permet de fournir une version du plugin Cadastre compatible avec les versions de QGIS après la 3.10.

Ce fix ne supprime pas les dépendances à db_manager. La suppression de cette dépendance demande un travail important de refactoring.
 
Financé par le [Ministère de la Transition écologique et solidaire](https://www.gouvernement.fr/ministere-de-la-transition-ecologique-et-solidaire)