### PR TITLE
Compatibilité avec QGIS > 3.10 - fetchDataFromSqlQuery

### DIFF
--- a/cadastre/cadastre_common_base.py
+++ b/cadastre/cadastre_common_base.py
@@ -178,6 +178,7 @@ def fetchDataFromSqlQuery(connector: 'DBConnector',
         ok = False
         print(e.msg)
         QgsMessageLog.logMessage("cadastre debug - error while fetching data from database")
+        print(sql)
 
     finally:
         if c:

--- a/cadastre/cadastre_dialogs.py
+++ b/cadastre/cadastre_dialogs.py
@@ -278,7 +278,7 @@ class CadastreCommon:
                 # Check for data in it
                 sql = 'SELECT * FROM "%s" LIMIT 1' % searchTable
                 if self.dialog.dbType == 'postgis':
-                    sql = 'SELECT * FROM "%s"."%s" LIMIT 1' % (self.dialog.schema, searchTable)
+                    sql = 'SELECT * FROM "{}"."{}" LIMIT 1'.format(self.dialog.schema, searchTable)
                 [header, data, rowCount, ok] = CadastreCommon.fetchDataFromSqlQuery(self.dialog.db.connector, sql)
                 if ok and rowCount >= 1:
                     hasData = True
@@ -286,7 +286,7 @@ class CadastreCommon:
                 # Check for Majic data in it
                 sql = 'SELECT * FROM "%s" LIMIT 1' % majicTableParcelle
                 if self.dialog.dbType == 'postgis':
-                    sql = 'SELECT * FROM "%s"."%s" LIMIT 1' % (self.dialog.schema, majicTableParcelle)
+                    sql = 'SELECT * FROM "{}"."{}" LIMIT 1'.format(self.dialog.schema, majicTableParcelle)
                 [header, data, rowCount, ok] = CadastreCommon.fetchDataFromSqlQuery(self.dialog.db.connector, sql)
                 if ok and rowCount >= 1:
                     hasMajicData = True
@@ -295,7 +295,7 @@ class CadastreCommon:
                 # Check for Majic data in it
                 sql = 'SELECT * FROM "%s" LIMIT 1' % majicTableProp
                 if self.dialog.dbType == 'postgis':
-                    sql = 'SELECT * FROM "%s"."%s" LIMIT 1' % (self.dialog.schema, majicTableProp)
+                    sql = 'SELECT * FROM "{}"."{}" LIMIT 1'.format(self.dialog.schema, majicTableProp)
                 [header, data, rowCount, ok] = CadastreCommon.fetchDataFromSqlQuery(self.dialog.db.connector, sql)
                 if ok and rowCount >= 1:
                     hasMajicData = True
@@ -304,7 +304,7 @@ class CadastreCommon:
                 # Check for Majic data in it
                 sql = 'SELECT * FROM "%s" LIMIT 1' % majicTableVoie
                 if self.dialog.dbType == 'postgis':
-                    sql = 'SELECT * FROM "%s"."%s" LIMIT 1' % (self.dialog.schema, majicTableVoie)
+                    sql = 'SELECT * FROM "{}"."{}" LIMIT 1'.format(self.dialog.schema, majicTableVoie)
                 [header, data, rowCount, ok] = CadastreCommon.fetchDataFromSqlQuery(self.dialog.db.connector, sql)
                 if ok and rowCount >= 1:
                     hasMajicData = True
@@ -1233,28 +1233,28 @@ class CadastreSearchDialog(QDockWidget, SEARCH_FORM_CLASS):
                 majicTableVoie = 'voie'
 
                 # dbType
-                postgisDbType = (self.connectionParams['dbType'] == 'postgis')
+                is_postgis = (self.connectionParams['dbType'] == 'postgis')
 
                 # Get data from table proprietaire
-                sql = 'SELECT * FROM "%s" LIMIT 1' % majicTableProp
-                if postgisDbType:
-                    sql = 'SELECT * FROM "%s"."%s" LIMIT 1' % (self.connectionParams['schema'], majicTableProp)
+                sql = 'SELECT * FROM "{}" LIMIT 1'.format(majicTableProp)
+                if is_postgis:
+                    sql = 'SELECT * FROM "{}"."{}" LIMIT 1'.format(self.connectionParams['schema'], majicTableProp)
                 [header, data, rowCount, ok] = CadastreCommon.fetchDataFromSqlQuery(connector, sql)
                 if ok and rowCount >= 1:
                     self.hasMajicDataProp = True
 
                 # Get data from table voie
-                sql = 'SELECT * FROM "%s" LIMIT 1' % majicTableVoie
-                if postgisDbType:
-                    sql = 'SELECT * FROM "%s"."%s" LIMIT 1' % (self.connectionParams['schema'], majicTableVoie)
+                sql = 'SELECT * FROM "{}" LIMIT 1'.format(majicTableVoie)
+                if is_postgis:
+                    sql = 'SELECT * FROM "{}"."{}" LIMIT 1'.format(self.connectionParams['schema'], majicTableVoie)
                 [header, data, rowCount, ok] = CadastreCommon.fetchDataFromSqlQuery(connector, sql)
                 if ok and rowCount >= 1:
                     self.hasMajicDataVoie = True
 
                 # Get data from table parcelle
-                sql = 'SELECT * FROM "%s" LIMIT 1' % majicTableParcelle
-                if postgisDbType:
-                    sql = 'SELECT * FROM "%s"."%s" LIMIT 1' % (self.connectionParams['schema'], majicTableParcelle)
+                sql = 'SELECT * FROM "{}" LIMIT 1'.format(majicTableParcelle)
+                if is_postgis:
+                    sql = 'SELECT * FROM "{}"."{}" LIMIT 1'.format(self.connectionParams['schema'], majicTableParcelle)
                 [header, data, rowCount, ok] = CadastreCommon.fetchDataFromSqlQuery(connector, sql)
                 if ok and rowCount >= 1:
                     self.hasMajicDataParcelle = True
@@ -1438,12 +1438,12 @@ class CadastreSearchDialog(QDockWidget, SEARCH_FORM_CLASS):
         if key == 'adresse':
             sql = ' SELECT DISTINCT v.voie, c.tex2 AS libcom, v.natvoi, v.libvoi'
             if self.dbType == 'postgis':
-                sql += ' FROM "%s"."voie" v' % connectionParams['schema']
+                sql += ' FROM "{}"."voie" v'.format(connectionParams['schema'])
             else:
                 sql += ' FROM voie v'
             # filter among commune existing in geo_commune
             if self.dbType == 'postgis':
-                sql += ' INNER JOIN "%s"."geo_commune" c ON c.commune = v.commune' % connectionParams['schema']
+                sql += ' INNER JOIN "{}"."geo_commune" c ON c.commune = v.commune'.format(connectionParams['schema'])
             else:
                 sql += ' INNER JOIN geo_commune c ON c.commune = v.commune'
             sql += " WHERE 2>1"
@@ -1465,7 +1465,7 @@ class CadastreSearchDialog(QDockWidget, SEARCH_FORM_CLASS):
         if key == 'proprietaire':
             sql = " SELECT trim(ddenom) AS k, MyStringAgg(comptecommunal, ',') AS cc, dnuper"  # , c.ccocom"
             if self.dbType == 'postgis':
-                sql += ' FROM "%s"."proprietaire" p' % connectionParams['schema']
+                sql += ' FROM "{}"."proprietaire" p'.format(connectionParams['schema'])
             else:
                 sql += ' FROM proprietaire p'
             # ~ sql+= ' INNER JOIN commune c ON c.ccocom = p.ccocom'
@@ -1583,7 +1583,7 @@ class CadastreSearchDialog(QDockWidget, SEARCH_FORM_CLASS):
         # Build table name
         f = '"%s"' % table
         if self.dbType == 'postgis':
-            f = '"%s"."%s"' % (connectionParams['schema'], table)
+            f = '"{}"."{}"'.format(connectionParams['schema'], table)
 
         # SQL
         sql += ' FROM %s' % f
@@ -2690,7 +2690,7 @@ class CadastreParcelleDialog(QDialog, PARCELLE_FORM_CLASS):
         self.hasMajicDataProp = False
         sql = 'SELECT * FROM "proprietaire" LIMIT 1'
         if self.connectionParams['dbType'] == 'postgis':
-            sql = 'SELECT * FROM "%s"."proprietaire" LIMIT 1' % self.connectionParams['schema']
+            sql = 'SELECT * FROM "{}"."proprietaire" LIMIT 1'.format(self.connectionParams['schema'])
         [header, data, rowCount, ok] = CadastreCommon.fetchDataFromSqlQuery(self.connector, sql)
         if ok and rowCount >= 1:
             self.hasMajicDataProp = True

--- a/cadastre/cadastre_dialogs.py
+++ b/cadastre/cadastre_dialogs.py
@@ -261,10 +261,10 @@ class CadastreCommon:
         hasMajicDataParcelle = False
         hasMajicDataVoie = False
 
-        searchTable = u'geo_commune'
-        majicTableParcelle = u'parcelle'
-        majicTableProp = u'proprietaire'
-        majicTableVoie = u'voie'
+        searchTable = 'geo_commune'
+        majicTableParcelle = 'parcelle'
+        majicTableProp = 'proprietaire'
+        majicTableVoie = 'voie'
         if self.dialog.db:
             if self.dialog.dbType == 'postgis':
                 schemaSearch = [s for s in self.dialog.db.schemas() if s.name == self.dialog.schema]
@@ -278,7 +278,7 @@ class CadastreCommon:
                 # Check for data in it
                 sql = 'SELECT * FROM "%s" LIMIT 1' % searchTable
                 if self.dialog.dbType == 'postgis':
-                    sql = CadastreCommon.setSearchPath(sql, self.dialog.schema)
+                    sql = 'SELECT * FROM "%s"."%s" LIMIT 1' % (self.dialog.schema, searchTable)
                 [header, data, rowCount, ok] = CadastreCommon.fetchDataFromSqlQuery(self.dialog.db.connector, sql)
                 if ok and rowCount >= 1:
                     hasData = True
@@ -286,7 +286,7 @@ class CadastreCommon:
                 # Check for Majic data in it
                 sql = 'SELECT * FROM "%s" LIMIT 1' % majicTableParcelle
                 if self.dialog.dbType == 'postgis':
-                    sql = CadastreCommon.setSearchPath(sql, self.dialog.schema)
+                    sql = 'SELECT * FROM "%s"."%s" LIMIT 1' % (self.dialog.schema, majicTableParcelle)
                 [header, data, rowCount, ok] = CadastreCommon.fetchDataFromSqlQuery(self.dialog.db.connector, sql)
                 if ok and rowCount >= 1:
                     hasMajicData = True
@@ -295,7 +295,7 @@ class CadastreCommon:
                 # Check for Majic data in it
                 sql = 'SELECT * FROM "%s" LIMIT 1' % majicTableProp
                 if self.dialog.dbType == 'postgis':
-                    sql = CadastreCommon.setSearchPath(sql, self.dialog.schema)
+                    sql = 'SELECT * FROM "%s"."%s" LIMIT 1' % (self.dialog.schema, majicTableProp)
                 [header, data, rowCount, ok] = CadastreCommon.fetchDataFromSqlQuery(self.dialog.db.connector, sql)
                 if ok and rowCount >= 1:
                     hasMajicData = True
@@ -304,7 +304,7 @@ class CadastreCommon:
                 # Check for Majic data in it
                 sql = 'SELECT * FROM "%s" LIMIT 1' % majicTableVoie
                 if self.dialog.dbType == 'postgis':
-                    sql = CadastreCommon.setSearchPath(sql, self.dialog.schema)
+                    sql = 'SELECT * FROM "%s"."%s" LIMIT 1' % (self.dialog.schema, majicTableVoie)
                 [header, data, rowCount, ok] = CadastreCommon.fetchDataFromSqlQuery(self.dialog.db.connector, sql)
                 if ok and rowCount >= 1:
                     hasMajicData = True
@@ -1227,26 +1227,34 @@ class CadastreSearchDialog(QDockWidget, SEARCH_FORM_CLASS):
             # Get Connection params
             connector = CadastreCommon.getConnectorFromUri(self.connectionParams)
             if connector:
+                # Tables to check
+                majicTableParcelle = 'parcelle'
+                majicTableProp = 'proprietaire'
+                majicTableVoie = 'voie'
+
+                # dbType
+                postgisDbType = (self.connectionParams['dbType'] == 'postgis')
+
                 # Get data from table proprietaire
-                sql = 'SELECT * FROM "proprietaire" LIMIT 1'
-                if self.connectionParams['dbType'] == 'postgis':
-                    sql = CadastreCommon.setSearchPath(sql, self.connectionParams['schema'])
+                sql = 'SELECT * FROM "%s" LIMIT 1' % majicTableProp
+                if postgisDbType:
+                    sql = 'SELECT * FROM "%s"."%s" LIMIT 1' % (self.connectionParams['schema'], majicTableProp)
                 [header, data, rowCount, ok] = CadastreCommon.fetchDataFromSqlQuery(connector, sql)
                 if ok and rowCount >= 1:
                     self.hasMajicDataProp = True
 
                 # Get data from table voie
-                sql = 'SELECT * FROM "voie" LIMIT 1'
-                if self.connectionParams['dbType'] == 'postgis':
-                    sql = CadastreCommon.setSearchPath(sql, self.connectionParams['schema'])
+                sql = 'SELECT * FROM "%s" LIMIT 1' % majicTableVoie
+                if postgisDbType:
+                    sql = 'SELECT * FROM "%s"."%s" LIMIT 1' % (self.connectionParams['schema'], majicTableVoie)
                 [header, data, rowCount, ok] = CadastreCommon.fetchDataFromSqlQuery(connector, sql)
                 if ok and rowCount >= 1:
                     self.hasMajicDataVoie = True
 
                 # Get data from table parcelle
-                sql = 'SELECT * FROM "parcelle" LIMIT 1'
-                if self.connectionParams['dbType'] == 'postgis':
-                    sql = CadastreCommon.setSearchPath(sql, self.connectionParams['schema'])
+                sql = 'SELECT * FROM "%s" LIMIT 1' % majicTableParcelle
+                if postgisDbType:
+                    sql = 'SELECT * FROM "%s"."%s" LIMIT 1' % (self.connectionParams['schema'], majicTableParcelle)
                 [header, data, rowCount, ok] = CadastreCommon.fetchDataFromSqlQuery(connector, sql)
                 if ok and rowCount >= 1:
                     self.hasMajicDataParcelle = True
@@ -1429,9 +1437,15 @@ class CadastreSearchDialog(QDockWidget, SEARCH_FORM_CLASS):
         hasCommuneFilter = None
         if key == 'adresse':
             sql = ' SELECT DISTINCT v.voie, c.tex2 AS libcom, v.natvoi, v.libvoi'
-            sql += ' FROM voie v'
+            if self.dbType == 'postgis':
+                sql += ' FROM "%s"."voie" v' % connectionParams['schema']
+            else:
+                sql += ' FROM voie v'
             # filter among commune existing in geo_commune
-            sql += ' INNER JOIN geo_commune c ON c.commune = v.commune'
+            if self.dbType == 'postgis':
+                sql += ' INNER JOIN "%s"."geo_commune" c ON c.commune = v.commune' % connectionParams['schema']
+            else:
+                sql += ' INNER JOIN geo_commune c ON c.commune = v.commune'
             sql += " WHERE 2>1"
             for sv in searchValues:
                 sql += " AND libvoi LIKE %s" % self.connector.quoteString('%' + sv + '%')
@@ -1450,7 +1464,10 @@ class CadastreSearchDialog(QDockWidget, SEARCH_FORM_CLASS):
 
         if key == 'proprietaire':
             sql = " SELECT trim(ddenom) AS k, MyStringAgg(comptecommunal, ',') AS cc, dnuper"  # , c.ccocom"
-            sql += ' FROM proprietaire p'
+            if self.dbType == 'postgis':
+                sql += ' FROM "%s"."proprietaire" p' % connectionParams['schema']
+            else:
+                sql += ' FROM proprietaire p'
             # ~ sql+= ' INNER JOIN commune c ON c.ccocom = p.ccocom'
             sql += " WHERE 2>1"
             for sv in searchValues:
@@ -1458,8 +1475,9 @@ class CadastreSearchDialog(QDockWidget, SEARCH_FORM_CLASS):
             sql += ' GROUP BY dnuper, ddenom, dlign4'  # , c.ccocom'
             sql += ' ORDER BY ddenom'  # , c.ccocom'
         self.dbType = connectionParams['dbType']
+
+        # Update aggregate function in SQL
         if self.dbType == 'postgis':
-            sql = CadastreCommon.setSearchPath(sql, connectionParams['schema'])
             sql = sql.replace('MyStringAgg', 'string_agg')
         else:
             sql = sql.replace('MyStringAgg', 'group_concat')
@@ -1562,7 +1580,12 @@ class CadastreSearchDialog(QDockWidget, SEARCH_FORM_CLASS):
         table = connectionParams['table']
         if table == 'geo_parcelle':
             table = 'parcelle_info'
+        # Build table name
         f = '"%s"' % table
+        if self.dbType == 'postgis':
+            f = '"%s"."%s"' % (connectionParams['schema'], table)
+
+        # SQL
         sql += ' FROM %s' % f
         sql += " WHERE 2>1"
         if filterExpression:
@@ -1570,8 +1593,6 @@ class CadastreSearchDialog(QDockWidget, SEARCH_FORM_CLASS):
         if orderBy:
             sql += ' ORDER BY %s' % ', '.join(orderBy)
 
-        if self.dbType == 'postgis':
-            sql = CadastreCommon.setSearchPath(sql, connectionParams['schema'])
         # Get data
         # self.qc.updateLog(sql)
         [header, data, rowCount, ok] = CadastreCommon.fetchDataFromSqlQuery(connector, sql)
@@ -2669,7 +2690,7 @@ class CadastreParcelleDialog(QDialog, PARCELLE_FORM_CLASS):
         self.hasMajicDataProp = False
         sql = 'SELECT * FROM "proprietaire" LIMIT 1'
         if self.connectionParams['dbType'] == 'postgis':
-            sql = CadastreCommon.setSearchPath(sql, self.connectionParams['schema'])
+            sql = 'SELECT * FROM "%s"."proprietaire" LIMIT 1' % self.connectionParams['schema']
         [header, data, rowCount, ok] = CadastreCommon.fetchDataFromSqlQuery(self.connector, sql)
         if ok and rowCount >= 1:
             self.hasMajicDataProp = True

--- a/cadastre/cadastre_export.py
+++ b/cadastre/cadastre_export.py
@@ -307,7 +307,7 @@ class cadastreExport:
 
             # Add schema to search_path if postgis
             if self.dbType == 'postgis':
-                sql = sql.replace('$schema', '"%s".' % self.connectionParams['schema'])
+                sql = sql.replace('$schema', '"{}".'.format(self.connectionParams['schema']))
             else:
                 sql = sql.replace('$schema', '')
             # Add where clause depending on etype

--- a/cadastre/cadastre_export.py
+++ b/cadastre/cadastre_export.py
@@ -308,7 +308,6 @@ class cadastreExport:
             # Add schema to search_path if postgis
             if self.dbType == 'postgis':
                 sql = sql.replace('$schema', '"%s".' % self.connectionParams['schema'])
-                #sql = cadastre_common.setSearchPath(sql, self.connectionParams['schema'])
             else:
                 sql = sql.replace('$schema', '')
             # Add where clause depending on etype

--- a/cadastre/cadastre_export.py
+++ b/cadastre/cadastre_export.py
@@ -307,7 +307,10 @@ class cadastreExport:
 
             # Add schema to search_path if postgis
             if self.dbType == 'postgis':
-                sql = cadastre_common.setSearchPath(sql, self.connectionParams['schema'])
+                sql = sql.replace('$schema', '"%s".' % self.connectionParams['schema'])
+                #sql = cadastre_common.setSearchPath(sql, self.connectionParams['schema'])
+            else:
+                sql = sql.replace('$schema', '')
             # Add where clause depending on etype
             sql = sql.replace('$and', item['and'][self.etype])
 

--- a/cadastre/templates/header1.tpl.sql
+++ b/cadastre/templates/header1.tpl.sql
@@ -1,7 +1,7 @@
 
 SELECT p.annee, p.ccodep, p.ccodir, p.ccocom, c.libcom
-FROM proprietaire p
-LEFT OUTER JOIN commune c ON c.ccocom = p.ccocom AND c.ccodep = p.ccodep
+FROM $schema"proprietaire" p
+LEFT OUTER JOIN $schema"commune" c ON c.ccocom = p.ccocom AND c.ccodep = p.ccodep
 WHERE 2>1
 $and
 LIMIT 1

--- a/cadastre/templates/proprietaires_line.tpl.sql
+++ b/cadastre/templates/proprietaires_line.tpl.sql
@@ -7,8 +7,8 @@ CASE
   THEN ' Né(e) le ' || jdatnss || ' à ' || coalesce(p.dldnss, '')
   ELSE ''
 END AS nele
-FROM proprietaire p
-INNER JOIN ccodro ON ccodro.ccodro = p.ccodro
+FROM $schema"proprietaire" p
+INNER JOIN $schema"ccodro" cc ON cc.ccodro = p.ccodro
 WHERE 2>1
 $and
 

--- a/cadastre/templates/proprietes_baties_line.tpl.sql
+++ b/cadastre/templates/proprietes_baties_line.tpl.sql
@@ -15,13 +15,13 @@ END AS revenucadastral,
 px.ccolloc AS coll, px.gnextl AS natexo, px.janimp AS anret, px.jandeb AS andeb, Cast(px.rcexba2 * px.pexb / 100 AS numeric(10,2)) AS fractionrcexo,
 px.pexb AS pourcentageexo, l10.gtauom AS txom, '' AS coefreduc
 FROM
-parcelle p
-INNER JOIN local00 l ON l.parcelle = p.parcelle
-INNER JOIN local10 l10 ON l10.local00 = l.local00
-INNER JOIN pev ON pev.local10 = l10.local10
-LEFT OUTER JOIN voie v ON v.voie = l.voie
-LEFT JOIN pevexoneration px ON px.pev = pev.pev
-LEFT JOIN pevtaxation pt ON pt.pev = pev.pev
+$schema"parcelle" p
+INNER JOIN $schema"local00" l ON l.parcelle = p.parcelle
+INNER JOIN $schema"local10" l10 ON l10.local00 = l.local00
+INNER JOIN $schema"pev" pev ON pev.local10 = l10.local10
+LEFT OUTER JOIN $schema"voie" v ON v.voie = l.voie
+LEFT JOIN $schema"pevexoneration" px ON px.pev = pev.pev
+LEFT JOIN $schema"pevtaxation" pt ON pt.pev = pev.pev
 WHERE 2>1
 $and
 ORDER BY p.parcelle, l.dnvoiri, v.natvoi, v.libvoi, bat, ent, niv

--- a/cadastre/templates/proprietes_baties_sum.tpl.sql
+++ b/cadastre/templates/proprietes_baties_sum.tpl.sql
@@ -11,12 +11,12 @@ Coalesce(Sum(Cast(pt.gp_vlbaia * px.pexb / 100 AS numeric(10,2))) , 0) as gp_vlb
 Coalesce(Sum(Cast(pt.de_vlbaia * px.pexb / 100 AS numeric(10,2))) , 0) as de_vlbaia, sum(pt.de_bipevla) as de_bipevla,
 Coalesce(Sum(Cast(pt.re_vlbaia * px.pexb / 100 AS numeric(10,2))) , 0) as re_vlbaia, Coalesce(sum(pt.re_bipevla), 0)  as re_bipevla
 FROM
-parcelle p
-INNER JOIN local00 l ON l.parcelle = p.parcelle
-INNER JOIN local10 l10 ON l10.local00 = l.local00
-INNER JOIN pev ON pev.local10 = l10.local10
-LEFT JOIN pevexoneration px ON px.pev = pev.pev
-LEFT JOIN pevtaxation pt ON pt.pev = pev.pev
+$schema"parcelle" p
+INNER JOIN $schema"local00" l ON l.parcelle = p.parcelle
+INNER JOIN $schema"local10" l10 ON l10.local00 = l.local00
+INNER JOIN $schema"pev" pev ON pev.local10 = l10.local10
+LEFT JOIN $schema"pevexoneration" px ON px.pev = pev.pev
+LEFT JOIN $schema"pevtaxation" pt ON pt.pev = pev.pev
 WHERE 2>1
 $and
 

--- a/cadastre/templates/proprietes_non_baties_line.tpl.sql
+++ b/cadastre/templates/proprietes_non_baties_line.tpl.sql
@@ -14,10 +14,10 @@ round(Cast(s.drcsuba * Cast(se.pexn / 100 AS numeric(10,2)) / 100 AS numeric) , 
 Cast(se.pexn / 100 AS numeric(10,2)) AS pourcentageexo, '' AS tc,
 p.dreflf AS lff
 
-FROM parcelle p
-INNER JOIN suf s ON p.parcelle = s.parcelle
-LEFT OUTER JOIN voie v ON v.voie = p.voie
-LEFT JOIN sufexoneration se ON s.suf = se.suf
+FROM $schema"parcelle" p
+INNER JOIN $schema"suf" s ON p.parcelle = s.parcelle
+LEFT OUTER JOIN $schema"voie" v ON v.voie = p.voie
+LEFT JOIN $schema"sufexoneration" se ON s.suf = se.suf
 WHERE 2>1
 $and
 ORDER BY p.parcelle, s.suf

--- a/cadastre/templates/proprietes_non_baties_sum.tpl.sql
+++ b/cadastre/templates/proprietes_non_baties_sum.tpl.sql
@@ -6,8 +6,8 @@ CASE WHEN length(Cast(sum(s.dcntsf) AS text)) > 0 THEN substring(Cast(sum(s.dcnt
 
 sum(s.drcsuba) AS sum_drcsuba
 
-FROM parcelle p
-INNER JOIN suf s ON p.parcelle = s.parcelle
+FROM $schema"parcelle" p
+INNER JOIN $schema"suf" s ON p.parcelle = s.parcelle
 --LEFT JOIN sufexoneration se ON s.suf = se.suf
 WHERE 2>1
 $and


### PR DESCRIPTION
Les changements dans db_manager nécessite de faire attention à la structure des requêtes dans le cas d'un `fetchDataFromSqlQuery`

Dans ce cas, il n'est pas possible d'utiliser `SET search_path`, il faut utiliser le schema directement dans le nom des table.

* Ticket  #227 
* Complète #264 

Financé par le [Ministère de la Transition écologique et solidaire](https://www.gouvernement.fr/ministere-de-la-transition-ecologique-et-solidaire)
