### PR TITLE
WIP fix(CompteCommunal): change order of building sql query to avoid synt…

### DIFF
--- a/cadastre/cadastre_common_base.py
+++ b/cadastre/cadastre_common_base.py
@@ -342,10 +342,10 @@ def postgisToSpatialiteLocal10(sql: str, dataYear: str) -> str:
 def getCompteCommunalFromParcelleId(parcelleId: str, connectionParams: Dict[str, str],
                                     connector: 'DBConnector') -> Union[str, None]:
     comptecommunal = None
-
-    sql = "SELECT comptecommunal FROM parcelle WHERE parcelle = '%s'" % parcelleId
+    sql = ''
     if connectionParams['dbType'] == 'postgis':
-        sql = setSearchPath(sql, connectionParams['schema'])
+        sql += setSearchPath(sql, connectionParams['schema'])
+    sql += "SELECT comptecommunal FROM parcelle WHERE parcelle = '%s'" % parcelleId
     [header, data, rowCount, ok] = fetchDataFromSqlQuery(connector, sql)
     if ok:
         for line in data:


### PR DESCRIPTION
Fixes 
```
ERROR:  syntax error at or near "=" at character 80
STATEMENT:  SELECT * FROM (SELECT row_number() OVER () AS __rid__, * FROM (SET search_path = "ccccc", public, pg_catalog;SELECT comptecommunal FROM parcelle WHERE parcelle = '7401360000B0003') as foo) AS "subQuery_0" LIMIT 1
```
By changing the construction order of the sql query
