### PR TITLE
Recherche proprio par nom d'usage ou de naissance

### DIFF
--- a/cadastre/cadastre_dialogs.py
+++ b/cadastre/cadastre_dialogs.py
@@ -1539,7 +1539,7 @@ class CadastreSearchDialog(QDockWidget, SEARCH_FORM_CLASS):
 
             if key == 'proprietaire':
                 # ~ label = '%s - %s | %s' % (line[3], line[2], line[0].strip())
-                label = '%s | %s' % (line[2], line[0].strip())
+                label = '%s | %s' % (line[1], line[0].strip())
                 val = {
                     'cc': ["'%s'" % a for a in line[1].split(',')],
                     'dnuper': line[2]

--- a/cadastre/forms/cadastre_search_form.ui
+++ b/cadastre/forms/cadastre_search_form.ui
@@ -229,7 +229,7 @@
           <layout class="QVBoxLayout" name="verticalLayout_2">
            <item>
             <layout class="QGridLayout" name="gridLayout_2">
-             <item row="0" column="3">
+             <item row="1" column="3">
               <widget class="QToolButton" name="btExportProprietaire">
                <property name="toolTip">
                 <string>Exporter le relevé de propriété</string>
@@ -239,7 +239,18 @@
                </property>
               </widget>
              </item>
-             <item row="1" column="1">
+             <!--Checkbox-->
+            <item row="0" column="1">
+             <widget class="QCheckBox" name="cbSearchNameBirth">
+              <property name="text">
+               <string>Rechercher par nom de naissance</string>
+              </property>
+              <property name="checked">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+             <item row="2" column="1">
               <widget class="QComboBox" name="liParcelleProprietaire">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -252,7 +263,7 @@
                </property>
               </widget>
              </item>
-             <item row="0" column="1">
+             <item row="1" column="1">
               <widget class="QComboBox" name="liProprietaire">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -265,7 +276,7 @@
                </property>
               </widget>
              </item>
-             <item row="1" column="0">
+             <item row="2" column="0">
               <widget class="QLabel" name="label_3">
                <property name="maximumSize">
                 <size>
@@ -278,14 +289,14 @@
                </property>
               </widget>
              </item>
-             <item row="0" column="0">
+             <item row="1" column="0">
               <widget class="QLabel" name="label_4">
                <property name="text">
                 <string>Nom</string>
                </property>
               </widget>
              </item>
-             <item row="1" column="3">
+             <item row="2" column="3">
               <widget class="QToolButton" name="btExportParcelleProprietaire">
                <property name="toolTip">
                 <string>Exporter le relevé parcellaire</string>
@@ -295,7 +306,7 @@
                </property>
               </widget>
              </item>
-             <item row="0" column="2">
+             <item row="1" column="2">
               <widget class="QToolButton" name="btResetProprietaire">
                <property name="toolTip">
                 <string>Retour à l'ensemble des parcelles</string>
@@ -305,7 +316,7 @@
                </property>
               </widget>
              </item>
-             <item row="1" column="2">
+             <item row="2" column="2">
               <widget class="QToolButton" name="btResetParcelleProprietaire">
                <property name="toolTip">
                 <string>Retour à l'ensemble des parcelles</string>


### PR DESCRIPTION
Cette PR permet de rechercher un propriétaire par nom d'usage ou nom de naissance tel que décrit dans l'issue #119.

Merci au Pôle Métropolitain du [Pays de Brest](https://www.pays-de-brest.fr/) cette contribution et les tests réalisés.
