### PR TITLE
Filtrer les propriétaires par commune

### DIFF
--- a/cadastre/cadastre_menu.py
+++ b/cadastre/cadastre_menu.py
@@ -422,6 +422,7 @@ class CadastreMenu:
             self.cadastre_search_dialog.clearComboboxes()
             self.cadastre_search_dialog.setupSearchCombobox('commune', None, 'sql')
             self.cadastre_search_dialog.setupSearchCombobox('section', None, 'sql')
+            self.cadastre_search_dialog.setupSearchCombobox('commune_proprietaire', None, 'sql')
             self.checkIdentifyParcelleTool()
 
     def onNewProjectCreated(self):

--- a/cadastre/forms/cadastre_search_form.ui
+++ b/cadastre/forms/cadastre_search_form.ui
@@ -229,7 +229,40 @@
           <layout class="QVBoxLayout" name="verticalLayout_2">
            <item>
             <layout class="QGridLayout" name="gridLayout_2">
-             <item row="1" column="3">
+             <!--commune proprietaire label-->
+             <item row="1" column="0">
+              <widget class="QLabel" name="label_19">
+               <property name="text">
+                <string>Commune</string>
+               </property>
+              </widget>
+             </item>
+             <!--reset commune proprietaire-->
+             <item row="1" column="2">
+              <widget class="QToolButton" name="btResetCommuneProprietaire">
+               <property name="toolTip">
+                <string>Retour à l'ensemble des communes</string>
+               </property>
+               <property name="text">
+                <string>...</string>
+               </property>
+              </widget>
+             </item>
+             <!--commune priprietaire combo-->
+             <item row="1" column="1">
+              <widget class="QComboBox" name="liCommuneProprietaire">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="editable">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="3">
               <widget class="QToolButton" name="btExportProprietaire">
                <property name="toolTip">
                 <string>Exporter le relevé de propriété</string>
@@ -250,7 +283,7 @@
               </property>
              </widget>
             </item>
-             <item row="2" column="1">
+             <item row="3" column="1">
               <widget class="QComboBox" name="liParcelleProprietaire">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -263,7 +296,7 @@
                </property>
               </widget>
              </item>
-             <item row="1" column="1">
+             <item row="2" column="1">
               <widget class="QComboBox" name="liProprietaire">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -276,7 +309,7 @@
                </property>
               </widget>
              </item>
-             <item row="2" column="0">
+             <item row="3" column="0">
               <widget class="QLabel" name="label_3">
                <property name="maximumSize">
                 <size>
@@ -289,14 +322,14 @@
                </property>
               </widget>
              </item>
-             <item row="1" column="0">
+             <item row="2" column="0">
               <widget class="QLabel" name="label_4">
                <property name="text">
                 <string>Nom</string>
                </property>
               </widget>
              </item>
-             <item row="2" column="3">
+             <item row="3" column="3">
               <widget class="QToolButton" name="btExportParcelleProprietaire">
                <property name="toolTip">
                 <string>Exporter le relevé parcellaire</string>
@@ -306,7 +339,7 @@
                </property>
               </widget>
              </item>
-             <item row="1" column="2">
+             <item row="2" column="2">
               <widget class="QToolButton" name="btResetProprietaire">
                <property name="toolTip">
                 <string>Retour à l'ensemble des parcelles</string>
@@ -316,7 +349,7 @@
                </property>
               </widget>
              </item>
-             <item row="2" column="2">
+             <item row="3" column="2">
               <widget class="QToolButton" name="btResetParcelleProprietaire">
                <property name="toolTip">
                 <string>Retour à l'ensemble des parcelles</string>


### PR DESCRIPTION
Cette PR permet de sélectionner une commune dans la zone de recherche d'un propriétaire afin de limiter la recherche d'un nom de propriétaire au sein d'une commune.

Ce comportement est décrit dans l'issue #260.

L'interface de recherche (combo) doit s'insérer sous la checkbox de la PR #274.
Je m'occuperai des adaptations à la validation de la revue.

Merci au Pôle Métropolitain du [Pays de Brest](https://www.pays-de-brest.fr/) cette contribution et les tests réalisés.