### PR TITLE
Remove unused return from fetchDataFromSqlQuery

### DIFF
--- a/cadastre/cadastre_dialogs.py
+++ b/cadastre/cadastre_dialogs.py
@@ -273,7 +273,7 @@ class CadastreCommon:
                 sql = 'SELECT * FROM "%s" LIMIT 1' % searchTable
                 if self.dialog.dbType == 'postgis':
                     sql = 'SELECT * FROM "{}"."{}" LIMIT 1'.format(self.dialog.schema, searchTable)
-                [header, data, rowCount, ok] = CadastreCommon.fetchDataFromSqlQuery(self.dialog.db.connector, sql)
+                data, rowCount, ok = CadastreCommon.fetchDataFromSqlQuery(self.dialog.db.connector, sql)
                 if ok and rowCount >= 1:
                     hasData = True
 
@@ -281,7 +281,7 @@ class CadastreCommon:
                 sql = 'SELECT * FROM "%s" LIMIT 1' % majicTableParcelle
                 if self.dialog.dbType == 'postgis':
                     sql = 'SELECT * FROM "{}"."{}" LIMIT 1'.format(self.dialog.schema, majicTableParcelle)
-                [header, data, rowCount, ok] = CadastreCommon.fetchDataFromSqlQuery(self.dialog.db.connector, sql)
+                data, rowCount, ok = CadastreCommon.fetchDataFromSqlQuery(self.dialog.db.connector, sql)
                 if ok and rowCount >= 1:
                     hasMajicData = True
                     hasMajicDataParcelle = True
@@ -290,7 +290,7 @@ class CadastreCommon:
                 sql = 'SELECT * FROM "%s" LIMIT 1' % majicTableProp
                 if self.dialog.dbType == 'postgis':
                     sql = 'SELECT * FROM "{}"."{}" LIMIT 1'.format(self.dialog.schema, majicTableProp)
-                [header, data, rowCount, ok] = CadastreCommon.fetchDataFromSqlQuery(self.dialog.db.connector, sql)
+                data, rowCount, ok = CadastreCommon.fetchDataFromSqlQuery(self.dialog.db.connector, sql)
                 if ok and rowCount >= 1:
                     hasMajicData = True
                     hasMajicDataProp = True
@@ -299,7 +299,7 @@ class CadastreCommon:
                 sql = 'SELECT * FROM "%s" LIMIT 1' % majicTableVoie
                 if self.dialog.dbType == 'postgis':
                     sql = 'SELECT * FROM "{}"."{}" LIMIT 1'.format(self.dialog.schema, majicTableVoie)
-                [header, data, rowCount, ok] = CadastreCommon.fetchDataFromSqlQuery(self.dialog.db.connector, sql)
+                data, rowCount, ok = CadastreCommon.fetchDataFromSqlQuery(self.dialog.db.connector, sql)
                 if ok and rowCount >= 1:
                     hasMajicData = True
                     hasMajicDataVoie = True
@@ -329,7 +329,7 @@ class CadastreCommon:
         if self.dialog.dbType == 'spatialite':
             sql = "SELECT name FROM sqlite_master WHERE type='table' AND name='%s'" % tableName
 
-        [header, data, rowCount, ok] = CadastreCommon.fetchDataFromSqlQuery(self.dialog.db.connector, sql)
+        data, rowCount, ok = CadastreCommon.fetchDataFromSqlQuery(self.dialog.db.connector, sql)
         if ok and rowCount >= 1:
             tableExists = True
 
@@ -1258,7 +1258,7 @@ class CadastreSearchDialog(QDockWidget, SEARCH_FORM_CLASS):
                 sql = 'SELECT * FROM "{}" LIMIT 1'.format(majicTableProp)
                 if is_postgis:
                     sql = 'SELECT * FROM "{}"."{}" LIMIT 1'.format(self.connectionParams['schema'], majicTableProp)
-                [header, data, rowCount, ok] = CadastreCommon.fetchDataFromSqlQuery(connector, sql)
+                data, rowCount, ok = CadastreCommon.fetchDataFromSqlQuery(connector, sql)
                 if ok and rowCount >= 1:
                     self.hasMajicDataProp = True
 
@@ -1266,7 +1266,7 @@ class CadastreSearchDialog(QDockWidget, SEARCH_FORM_CLASS):
                 sql = 'SELECT * FROM "{}" LIMIT 1'.format(majicTableVoie)
                 if is_postgis:
                     sql = 'SELECT * FROM "{}"."{}" LIMIT 1'.format(self.connectionParams['schema'], majicTableVoie)
-                [header, data, rowCount, ok] = CadastreCommon.fetchDataFromSqlQuery(connector, sql)
+                data, rowCount, ok = CadastreCommon.fetchDataFromSqlQuery(connector, sql)
                 if ok and rowCount >= 1:
                     self.hasMajicDataVoie = True
 
@@ -1274,7 +1274,7 @@ class CadastreSearchDialog(QDockWidget, SEARCH_FORM_CLASS):
                 sql = 'SELECT * FROM "{}" LIMIT 1'.format(majicTableParcelle)
                 if is_postgis:
                     sql = 'SELECT * FROM "{}"."{}" LIMIT 1'.format(self.connectionParams['schema'], majicTableParcelle)
-                [header, data, rowCount, ok] = CadastreCommon.fetchDataFromSqlQuery(connector, sql)
+                data, rowCount, ok = CadastreCommon.fetchDataFromSqlQuery(connector, sql)
                 if ok and rowCount >= 1:
                     self.hasMajicDataParcelle = True
 
@@ -1552,7 +1552,7 @@ class CadastreSearchDialog(QDockWidget, SEARCH_FORM_CLASS):
                 sql += "ORDER BY nom_naissance\r\n"
         sql += ' LIMIT 50'
 
-        [header, data, rowCount, ok] = CadastreCommon.fetchDataFromSqlQuery(connector, sql)
+        data, rowCount, ok = CadastreCommon.fetchDataFromSqlQuery(connector, sql)
 
         # Write message in log
         msg = u"%s résultats correpondent à '%s'" % (rowCount, searchValue)
@@ -1662,7 +1662,7 @@ class CadastreSearchDialog(QDockWidget, SEARCH_FORM_CLASS):
 
         # Get data
         # self.qc.updateLog(sql)
-        [header, data, rowCount, ok] = CadastreCommon.fetchDataFromSqlQuery(connector, sql)
+        data, rowCount, ok = CadastreCommon.fetchDataFromSqlQuery(connector, sql)
 
         # Get features
         features = []
@@ -2691,7 +2691,7 @@ class CadastreParcelleDialog(QDialog, PARCELLE_FORM_CLASS):
         sql = 'SELECT * FROM "proprietaire" LIMIT 1'
         if self.connectionParams['dbType'] == 'postgis':
             sql = 'SELECT * FROM "{}"."proprietaire" LIMIT 1'.format(self.connectionParams['schema'])
-        [header, data, rowCount, ok] = CadastreCommon.fetchDataFromSqlQuery(self.connector, sql)
+        data, rowCount, ok = CadastreCommon.fetchDataFromSqlQuery(self.connector, sql)
         if ok and rowCount >= 1:
             self.hasMajicDataProp = True
 

--- a/cadastre/cadastre_export.py
+++ b/cadastre/cadastre_export.py
@@ -328,7 +328,7 @@ class cadastreExport:
             # Run SQL only if data has not already been defined
             if data is None:
                 # print(sql)
-                [header, data, rowCount, ok] = cadastre_common.fetchDataFromSqlQuery(self.connector, sql)
+                data, rowCount, ok = cadastre_common.fetchDataFromSqlQuery(self.connector, sql)
 
             # Page no defined = means the query is here to
             # get line count and whole data for proprietes_baties & proprietes_non_baties

--- a/cadastre/cadastre_import.py
+++ b/cadastre/cadastre_import.py
@@ -69,7 +69,7 @@ class cadastreImport(QObject):
             if self.sourceAuth == 'IGNF':
                 sqlsearch = '%%AUTHORITY["IGNF","%s"]%%' % self.sourceSrid.upper()
                 sql = "SELECT auth_srid FROM spatial_ref_sys WHERE auth_name='IGNF' AND  srtext LIKE '%s' LIMIT 1" % sqlsearch
-                [header, data, rowCount, ok] = CadastreCommon.fetchDataFromSqlQuery(self.connector, sql)
+                data, rowCount, ok = CadastreCommon.fetchDataFromSqlQuery(self.connector, sql)
                 if rowCount == 1:
                     for line in data:
                         self.sourceSrid = str(line[0])


### PR DESCRIPTION
Avant : 

```bash
(.venv) etienne@longitude:~/dev/python/QgisCadastrePlugin (master)$ pylint cadastre | grep header
cadastre/cadastre_export.py:331:16: W0612: Unused variable 'header' (unused-variable)
cadastre/cadastre_dialogs.py:276:16: W0612: Unused variable 'header' (unused-variable)
cadastre/cadastre_dialogs.py:332:8: W0612: Unused variable 'header' (unused-variable)
cadastre/cadastre_dialogs.py:1261:16: W0612: Unused variable 'header' (unused-variable)
cadastre/cadastre_dialogs.py:1555:8: W0612: Unused variable 'header' (unused-variable)
cadastre/cadastre_dialogs.py:1665:8: W0612: Unused variable 'header' (unused-variable)
cadastre/cadastre_dialogs.py:2694:8: W0612: Unused variable 'header' (unused-variable)
cadastre/cadastre_import.py:72:16: W0612: Unused variable 'header' (unused-variable)
cadastre/cadastre_common_base.py:365:4: W0612: Unused variable 'header' (unused-variable)
cadastre/cadastre_common_base.py:392:4: W0612: Unused variable 'header' (unused-variable)
cadastre/cadastre_common_base.py:451:4: W0612: Unused variable 'header' (unused-variable)
```

Après : 

```
(.venv) etienne@longitude:~/dev/python/QgisCadastrePlugin (fetchDataSqlQuery)$ pylint cadastre | grep header
(.venv) etienne@longitude:~/dev/python/QgisCadastrePlugin (fetchDataSqlQuery)$ 
```

La variable `header` n'était jamais utilisée dans le code, donc suppression.
Idem pour `schema`.

Fixes #287

Superseded #292 and #293
