### PR TITLE
UX - Save/restore settings from the previous database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Sauvegarde et restoration des paramètres de la dernière base utilisée dans l'interface graphique
+
 ## 1.11.0 - 2020-05-21
 
 * Correction d'un espace dans l'adresse dans les propriétés baties, non baties


### PR DESCRIPTION
Feature annexe car j'avais besoin d'avoir la base de données et le schéma dans les settings de QGIS après un import et/ou un chargement dans l'extension Elements.

Donc j'ai pensé qu'il était pratique de pré-remplir les combobox dans la fenetre de chargement, après l'import, souvent, on souhaite la même base.

@mdouchin Est-ce qu'il y avait une raison pour ne pas enregistrer le type de connexion, le nom de la connexion et le schéma ?

J'ai bien vu la variable `self.sLists` mais elle ne contient pas toutes les infos.
