### PR TITLE
Ajout de clés primaires de type entier sur des couches geo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Ajout d'une clé primaire à la table geo_label
+* Modification de la clé primaire de la table geo_batiment et geo_subdsect pour être de type entier
 * Ajout des noms courts sur les couches et les groupes pour rendre le projet valide par défaut lors d'une publication
   sur Lizmap
 * Mise à jour de https://docs.3liz.org
@@ -59,12 +61,12 @@
 * Correction d'une erreur SQL lors de la consultation des infos parcelle sur QGIS 3.16 bureautique et serveur
 * Ajout du support QGIS 3.16
 * Ajout d'un bouton pour ouvrir l'aide depuis le menu principal d'aide de QGIS
-* Ajout de la recherche d'un propriétaire 
+* Ajout de la recherche d'un propriétaire
   * par nom d'usage ou de naissance
   * par ville
 * Ajout d'un téléchargeur Edigéo communal dans la boite à outils Processing
 * Documentation https://docs.3liz.org/QgisCadastrePlugin/
-  * Mise de la documentation au format MkDocs 
+  * Mise de la documentation au format MkDocs
   * Intégration de la documentation du module Lizmap
   * Ajout de la documentation automatique concernant les traitements Processing
   * Ajout de la documentation concernant la base de données avec SchémaSpy
@@ -72,7 +74,7 @@
 
 ## 1.10.2 - 2020-12-10
 
-* Correction sur la documentation 
+* Correction sur la documentation
 * Ajout d'une table de matières sur https://docs.3liz.org/QgisCadastrePlugin/
 * Afficher un message dans les logs si un fichier SQLite est manquant
 * Prévenir l'utilisateur sur les fichiers bz2 lors de l'import des fichiers Édigéo.

--- a/cadastre/scripts/plugin/commun_create_metier.sql
+++ b/cadastre/scripts/plugin/commun_create_metier.sql
@@ -998,7 +998,8 @@ CREATE TABLE geo_batiment
   tex text,
   creat_date date,
   update_dat date,
-  lot text
+  lot text,
+  ogc_fid serial NOT NULL
 );
 SELECT AddGeometryColumn ( current_schema::text, 'geo_batiment', 'geom', 2154 , 'MULTIPOLYGON', 2 );
 

--- a/cadastre/scripts/plugin/commun_create_metier.sql
+++ b/cadastre/scripts/plugin/commun_create_metier.sql
@@ -883,7 +883,8 @@ CREATE TABLE geo_subdsect
   dred date,
   creat_date date,
   update_dat date,
-  lot text
+  lot text,
+  ogc_fid serial NOT NULL
 );
 SELECT AddGeometryColumn ( current_schema::text, 'geo_subdsect', 'geom', 2154 , 'MULTIPOLYGON', 2 );
 

--- a/cadastre/scripts/plugin/commun_creation_contraintes.sql
+++ b/cadastre/scripts/plugin/commun_creation_contraintes.sql
@@ -25,7 +25,7 @@ ALTER TABLE [PREFIXE]commune_majic ADD CONSTRAINT commune_majic_pk PRIMARY KEY  
 ALTER TABLE [PREFIXE]voie ADD CONSTRAINT voie_pk PRIMARY KEY  (voie);
 ALTER TABLE [PREFIXE]geo_commune ADD CONSTRAINT geo_commune_pk PRIMARY KEY (ogc_fid);
 ALTER TABLE [PREFIXE]geo_section ADD CONSTRAINT geo_section_pk PRIMARY KEY (ogc_fid);
-ALTER TABLE [PREFIXE]geo_subdsect ADD CONSTRAINT geo_subdsect_pk PRIMARY KEY (geo_subdsect);
+ALTER TABLE [PREFIXE]geo_subdsect ADD CONSTRAINT geo_subdsect_pk PRIMARY KEY (ogc_fid);
 ALTER TABLE [PREFIXE]geo_parcelle ADD CONSTRAINT geo_parcelle_pk PRIMARY KEY (ogc_fid);
 ALTER TABLE [PREFIXE]geo_subdfisc ADD CONSTRAINT geo_subdfisc_pk PRIMARY KEY (geo_subdfisc );
 ALTER TABLE [PREFIXE]geo_subdfisc_parcelle ADD CONSTRAINT geo_subdfisc_parcelle_pk PRIMARY KEY (geo_subdfisc_parcelle );

--- a/cadastre/scripts/plugin/commun_creation_contraintes.sql
+++ b/cadastre/scripts/plugin/commun_creation_contraintes.sql
@@ -51,6 +51,7 @@ ALTER TABLE [PREFIXE]geo_tline ADD CONSTRAINT geo_tline_pk PRIMARY KEY (geo_tlin
 ALTER TABLE [PREFIXE]geo_tline_commune ADD CONSTRAINT geo_tline_commune_pk PRIMARY KEY (geo_tline_commune );
 ALTER TABLE [PREFIXE]geo_tsurf ADD CONSTRAINT geo_tsurf_pk PRIMARY KEY (geo_tsurf );
 ALTER TABLE [PREFIXE]geo_tsurf_commune ADD CONSTRAINT geo_tsurf_commune_pk PRIMARY KEY (geo_tsurf_commune );
+ALTER TABLE [PREFIXE]geo_label ADD CONSTRAINT geo_label_pk PRIMARY KEY (ogc_fid );
 ALTER TABLE [PREFIXE]geo_unite_fonciere ADD CONSTRAINT geo_unite_fonciere_pk PRIMARY KEY (id);
 
 --~ -- création clé étrangère;

--- a/cadastre/scripts/plugin/commun_creation_contraintes.sql
+++ b/cadastre/scripts/plugin/commun_creation_contraintes.sql
@@ -33,7 +33,7 @@ ALTER TABLE [PREFIXE]geo_voiep ADD CONSTRAINT geo_voiep_pk PRIMARY KEY (geo_voie
 ALTER TABLE [PREFIXE]geo_numvoie ADD CONSTRAINT geo_numvoie_pk PRIMARY KEY (geo_numvoie );
 ALTER TABLE [PREFIXE]geo_numvoie_parcelle ADD CONSTRAINT geo_numvoie_parcelle_pk PRIMARY KEY (geo_numvoie_parcelle );
 ALTER TABLE [PREFIXE]geo_lieudit ADD CONSTRAINT geo_lieudit_pk PRIMARY KEY (geo_lieudit );
-ALTER TABLE [PREFIXE]geo_batiment ADD CONSTRAINT geo_batiment_pk PRIMARY KEY (geo_batiment );
+ALTER TABLE [PREFIXE]geo_batiment ADD CONSTRAINT geo_batiment_pk PRIMARY KEY (ogc_fid );
 ALTER TABLE [PREFIXE]geo_batiment_parcelle ADD CONSTRAINT geo_batiment_parcelle_pk PRIMARY KEY (geo_batiment_parcelle );
 ALTER TABLE [PREFIXE]geo_zoncommuni ADD CONSTRAINT geo_zoncommuni_pk PRIMARY KEY (geo_zoncommuni );
 ALTER TABLE [PREFIXE]geo_tronfluv ADD CONSTRAINT geo_tronfluv_pk PRIMARY KEY (geo_tronfluv );


### PR DESCRIPTION
Il manquait une clé primaire à la table `geo_label` et les tables `geo_batiment` et `geo_subdsect` avaient une clé primaire de type texte et non de type entier.

*  Funded by Terre de Provence Agglomération
