### PR TITLE
[Bugfix] Recherche par propriétaire lorsque le schema Postgres nécessite des doubles quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Correction de la recherche par propriétaire lorsque le schema Postgres nécessite des doubles quotes
 * Ajout d'une clé primaire à la table geo_label
 * Modification de la clé primaire de la table geo_batiment et geo_subdsect pour être de type entier
 * Ajout des noms courts sur les couches et les groupes pour rendre le projet valide par défaut lors d'une publication

--- a/cadastre/dialogs/search_dialog.py
+++ b/cadastre/dialogs/search_dialog.py
@@ -617,8 +617,7 @@ class CadastreSearchDialog(QDockWidget, SEARCH_FORM_CLASS):
                 selectedCity = communeProprioCb['chosenFeature']['geo_commune']
 
             if self.dbType == "postgis":
-                PGschema = connectionParams["schema"]
-                sqlFrom = "  FROM " + PGschema + ".proprietaire\r\n"
+                sqlFrom = '  FROM "{}".proprietaire\r\n'.format(connectionParams['schema'])
                 cityJoin = ' INNER JOIN "{}"."commune" commune ON commune.ccocom = proprio.ccocom\r\n'.format(connectionParams['schema'])
             else:
                 sqlFrom = "  FROM proprietaire\r\n"


### PR DESCRIPTION
La construction de la requête de recherche par propriétaire n'appliquait pas de doubles quotes au nom du schema.
La requête devient donc invalide si le nom du schema nécessite des doubles quotes comma par exemple avec `2021` ou `Cadastre`.

* fixes #343
* funded by 3liz