### PR TITLE
Export des relevés - Ajout d'une option "Les relevés sont destinés à des tiers"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ cadastre.*.zip
 # Temp files
 *~
 *.bak
+
+# VSCode
+*.code-workspace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Export des relevés - Ajout d'une option "Les relevés sont destinés à des tiers" 
+  qui permet de ne pas faire figurer la date et le lieu de naissance des propriétaires dans les PDF.
 
 ## 1.15.1 - 2022-08-12
 

--- a/cadastre/dialogs/cadastre_export_dialog.py
+++ b/cadastre/dialogs/cadastre_export_dialog.py
@@ -67,12 +67,12 @@ def printProgress(self, nb: int) -> Generator[Callable[[int], None], None, None]
 class CadastreExport(cadastreExportBase):
 
     def __init__(self, layer: QgsMapLayer, etype: str, comptecommunal: str,
-                 geo_parcelle: str = None, target_dir: str = None) -> None:
+                 geo_parcelle: str = None, target_dir: str = None, for_third_party: bool = False) -> None:
 
         self.mProgress = printProgress
 
         super().__init__(QgsProject.instance(),
-                         layer, etype, comptecommunal, geo_parcelle, target_dir)
+                         layer, etype, comptecommunal, geo_parcelle, target_dir, for_third_party)
 
         self.print_parcelle_page = True
 

--- a/cadastre/dialogs/parcelle_dialog.py
+++ b/cadastre/dialogs/parcelle_dialog.py
@@ -418,7 +418,7 @@ class CadastreParcelleDialog(QDialog, PARCELLE_FORM_CLASS):
             return
 
         # Check if PDF must be exported for a third party or not
-        for_third_party = self.cbForThirdParty.isChecked()
+        for_third_party = self.combo_for_third_party.isChecked()
 
         if self.feature:
             comptecommunal = CadastreCommon.getCompteCommunalFromParcelleId(

--- a/cadastre/dialogs/parcelle_dialog.py
+++ b/cadastre/dialogs/parcelle_dialog.py
@@ -103,6 +103,7 @@ class CadastreParcelleDialog(QDialog, PARCELLE_FORM_CLASS):
         self.rejected.connect(self.onReject)
         self.buttonBox.rejected.connect(self.onReject)
         self.buttonBox.accepted.connect(self.onAccept)
+
         # Export buttons
         exportButtons = {
             'parcelle': self.btExportParcelle,
@@ -416,6 +417,9 @@ class CadastreParcelleDialog(QDialog, PARCELLE_FORM_CLASS):
             self.proprietairesInfo.setText(u'Pas de données de propriétaires dans la base')
             return
 
+        # Check if PDF must be exported for a third party or not
+        for_third_party = self.cbForThirdParty.isChecked()
+
         if self.feature:
             comptecommunal = CadastreCommon.getCompteCommunalFromParcelleId(
                 self.feature['geo_parcelle'],
@@ -435,7 +439,9 @@ class CadastreParcelleDialog(QDialog, PARCELLE_FORM_CLASS):
                         self.layer,
                         key,
                         comptecommunal,
-                        self.feature['geo_parcelle']
+                        self.feature['geo_parcelle'],
+                        None,
+                        for_third_party
                     )
                     qe.export_as_pdf()
 

--- a/cadastre/dialogs/search_dialog.py
+++ b/cadastre/dialogs/search_dialog.py
@@ -1218,7 +1218,7 @@ class CadastreSearchDialog(QDockWidget, SEARCH_FORM_CLASS):
 
         # If export are for third-party persons
         # we need to remove sensitive data
-        for_third_party = self.cbForThirdParty.isChecked()
+        for_third_party = self.combo_for_third_party.isChecked()
 
         qex = CadastreExport(
             QgsProject.instance(), layer, 'proprietaire', cc,
@@ -1268,7 +1268,7 @@ class CadastreSearchDialog(QDockWidget, SEARCH_FORM_CLASS):
 
         # If export are for third-party persons
         # we need to remove sensitive data
-        for_third_party = self.cbForThirdParty.isChecked()
+        for_third_party = self.combo_for_third_party.isChecked()
         qex = CadastreExport(
             QgsProject.instance(), layer, 'parcelle',
             compte_communal, feature['geo_parcelle'],

--- a/cadastre/dialogs/search_dialog.py
+++ b/cadastre/dialogs/search_dialog.py
@@ -1215,7 +1215,16 @@ class CadastreSearchDialog(QDockWidget, SEARCH_FORM_CLASS):
             return
 
         layer = self.searchComboBoxes['proprietaire']['layer']
-        qex = CadastreExport(QgsProject.instance(), layer, 'proprietaire', cc)
+
+        # If export are for third-party persons
+        # we need to remove sensitive data
+        for_third_party = self.cbForThirdParty.isChecked()
+
+        qex = CadastreExport(
+            QgsProject.instance(), layer, 'proprietaire', cc,
+            None, None,
+            for_third_party
+        )
 
         with OverrideCursor(Qt.WaitCursor):
             exports = qex.export_as_pdf()
@@ -1250,13 +1259,21 @@ class CadastreSearchDialog(QDockWidget, SEARCH_FORM_CLASS):
             self.qc.updateLog('Aucune parcelle sélectionnée !')
             return
 
+        # Get id of the owner
         compte_communal = CadastreCommon.getCompteCommunalFromParcelleId(
             feature['geo_parcelle'],
             self.connectionParams,
             self.connector
         )
+
+        # If export are for third-party persons
+        # we need to remove sensitive data
+        for_third_party = self.cbForThirdParty.isChecked()
         qex = CadastreExport(
-            QgsProject.instance(), layer, 'parcelle', compte_communal, feature['geo_parcelle'])
+            QgsProject.instance(), layer, 'parcelle',
+            compte_communal, feature['geo_parcelle'],
+            None, for_third_party
+        )
 
         with OverrideCursor(Qt.WaitCursor):
             exports = qex.export_as_pdf()

--- a/cadastre/forms/cadastre_parcelle_form.ui
+++ b/cadastre/forms/cadastre_parcelle_form.ui
@@ -165,7 +165,7 @@
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_3">
           <item>
-           <widget class="QCheckBox" name="cbForThirdParty">
+           <widget class="QCheckBox" name="combo_for_third_party">
             <property name="toolTip">
              <string>Lorsque cette case est cochée, les dates et lieux de naissance des propriétaires ne sont pas exportés dans les relevés PDF.</string>
             </property>

--- a/cadastre/forms/cadastre_parcelle_form.ui
+++ b/cadastre/forms/cadastre_parcelle_form.ui
@@ -120,35 +120,6 @@
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_5">
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout">
-            <item>
-             <widget class="QPushButton" name="btExportParcelle">
-              <property name="text">
-               <string>Relevé parcellaire</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_4">
-            <item>
-             <widget class="QPushButton" name="btExportProprietaire">
-              <property name="text">
-               <string>Relevé de propriété</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QCheckBox" name="cbExportAllCities">
-              <property name="text">
-               <string>Exporter pour toutes les communes</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
            <layout class="QHBoxLayout" name="horizontalLayout_2">
             <item>
              <widget class="QPushButton" name="btCentrer">
@@ -187,6 +158,60 @@
          </layout>
         </widget>
        </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox">
+         <property name="title">
+          <string>Export</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <item>
+           <widget class="QCheckBox" name="cbForThirdParty">
+            <property name="toolTip">
+             <string>Lorsque cette case est cochée, les dates et lieux de naissance des propriétaires ne sont pas exportés dans les relevés PDF.</string>
+            </property>
+            <property name="text">
+             <string>Les relevés sont destinés à des tiers</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <item>
+             <widget class="QPushButton" name="btExportParcelle">
+              <property name="text">
+               <string>Relevé parcellaire</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_4">
+            <item>
+             <widget class="QPushButton" name="btExportProprietaire">
+              <property name="text">
+               <string>Relevé de propriété</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="cbExportAllCities">
+              <property name="toolTip">
+               <string>Cocher cette case permet d'exporter le relevé de propriété pour toutes les communes. Cela peut être très long !</string>
+              </property>
+              <property name="text">
+               <string>Exporter pour toutes les communes</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
       </layout>
      </widget>
     </widget>
@@ -208,5 +233,6 @@
   <tabstop>btSelectionner</tabstop>
   <tabstop>buttonBox</tabstop>
  </tabstops>
+ <resources/>
  <connections/>
 </ui>

--- a/cadastre/forms/cadastre_search_form.ui
+++ b/cadastre/forms/cadastre_search_form.ui
@@ -25,8 +25,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>382</width>
-         <height>586</height>
+         <width>436</width>
+         <height>573</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -229,7 +229,6 @@
           <layout class="QVBoxLayout" name="verticalLayout_2">
            <item>
             <layout class="QGridLayout" name="gridLayout_2">
-             <!--commune proprietaire label-->
              <item row="1" column="0">
               <widget class="QLabel" name="label_19">
                <property name="text">
@@ -237,7 +236,6 @@
                </property>
               </widget>
              </item>
-             <!--reset commune proprietaire-->
              <item row="1" column="2">
               <widget class="QToolButton" name="btResetCommuneProprietaire">
                <property name="toolTip">
@@ -248,7 +246,6 @@
                </property>
               </widget>
              </item>
-             <!--commune priprietaire combo-->
              <item row="1" column="1">
               <widget class="QComboBox" name="liCommuneProprietaire">
                <property name="sizePolicy">
@@ -272,17 +269,16 @@
                </property>
               </widget>
              </item>
-             <!--Checkbox-->
-            <item row="0" column="1">
-             <widget class="QCheckBox" name="cbSearchNameBirth">
-              <property name="text">
-               <string>Rechercher par nom de naissance</string>
-              </property>
-              <property name="checked">
-               <bool>false</bool>
-              </property>
-             </widget>
-            </item>
+             <item row="0" column="1">
+              <widget class="QCheckBox" name="cbSearchNameBirth">
+               <property name="text">
+                <string>Rechercher par nom de naissance</string>
+               </property>
+               <property name="checked">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
              <item row="3" column="1">
               <widget class="QComboBox" name="liParcelleProprietaire">
                <property name="sizePolicy">
@@ -394,6 +390,28 @@
               </widget>
              </item>
             </layout>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="grpOptions">
+          <property name="title">
+           <string>Options</string>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_3">
+           <item>
+            <widget class="QCheckBox" name="cbForThirdParty">
+             <property name="toolTip">
+              <string>Lorsque cette case est cochée, les dates et lieux de naissance des propriétaires ne sont pas exportés dans les relevés PDF.</string>
+             </property>
+             <property name="text">
+              <string>Les relevés sont destinés à des tiers</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
            </item>
           </layout>
          </widget>

--- a/cadastre/forms/cadastre_search_form.ui
+++ b/cadastre/forms/cadastre_search_form.ui
@@ -401,7 +401,7 @@
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_3">
            <item>
-            <widget class="QCheckBox" name="cbForThirdParty">
+            <widget class="QCheckBox" name="combo_for_third_party">
              <property name="toolTip">
               <string>Lorsque cette case est cochée, les dates et lieux de naissance des propriétaires ne sont pas exportés dans les relevés PDF.</string>
              </property>

--- a/cadastre/standalone/export.py
+++ b/cadastre/standalone/export.py
@@ -49,6 +49,11 @@ parser.add_argument(
     help='Usage: Override Export type'
 )
 parser.add_argument(
+    '-S',
+    metavar='\"For third-party\"',
+    help='Usage: Specify the export is for third-party and must be simplified: use true or false'
+)
+parser.add_argument(
     '-O',
     metavar='\"Output log file\"',
     help='Usage: Override Output log file'
@@ -64,6 +69,8 @@ parcelle_layer = 'Parcelles'
 parcelle_id = '2018300189000EY0670'
 # -T = Export type ("proprietaire")
 export_type = 'parcelle'
+# -S = For third party ("True")
+for_third_party = False
 # -D = Target directory for PDF ("/tmp/")
 target_dir = '/tmp/'
 # -O = Output log file ("/tmp/export_cadastre.log")
@@ -78,6 +85,10 @@ if "-I" in sys.argv:
     parcelle_id = sys.argv[sys.argv.index("-I") + 1]
 if "-T" in sys.argv:
     export_type = sys.argv[sys.argv.index("-T") + 1]
+if "-S" in sys.argv:
+    _for_third_party = sys.argv[sys.argv.index("-S") + 1]
+    if _for_third_party.lower() == 'true':
+        for_third_party = True
 if "-D" in sys.argv:
     target_dir = sys.argv[sys.argv.index("-D") + 1]
 if "-O" in sys.argv:
@@ -143,7 +154,8 @@ qex = CadastreExport(
     export_type,
     comptecommunal,
     feat['geo_parcelle'],
-    target_dir
+    target_dir,
+    for_third_party
 )
 paths = qex.export_as_pdf()
 print(paths)

--- a/cadastre/templates/proprietaires_line.tpl.sql
+++ b/cadastre/templates/proprietaires_line.tpl.sql
@@ -3,7 +3,7 @@ SELECT Coalesce(ccodro_lib, '') || ' - ' || p.dnuper || ' - ' || trim(Coalesce(p
 CASE WHEN epxnee = 'NEE' THEN 'EP ' || trim(Coalesce(dnomlp, '')) || ' ' || trim(Coalesce(dprnlp, '')) ELSE '' END AS epousede,
 trim(Coalesce(p.dlign3, '')) || ' / ' || ltrim(trim(Coalesce(p.dlign4, '')), '0') || trim(Coalesce(p.dlign5, '')) || ' ' || trim(Coalesce(p.dlign6, '')) AS adrprop,
 CASE
-  WHEN jdatnss IS NOT NULL
+  WHEN jdatnss IS NOT NULL AND NOT $for_third_party
   THEN ' Né(e) le ' || jdatnss || ' à ' || coalesce(p.dldnss, '')
   ELSE ''
 END AS nele
@@ -11,4 +11,3 @@ FROM $schema"proprietaire" p
 INNER JOIN $schema"ccodro" cc ON cc.ccodro = p.ccodro
 WHERE 2>1
 $and
-


### PR DESCRIPTION
Une nouvelle case à cocher "Les relevés sont destinés à des tiers" est visible

* dans le panneau de recherche
* dans la popup d'identification de la parcelle

Elle est activée par défaut et a pour conséquence de ne pas exporter
les dates et lieux de naissance des propriétaires dans les relevés PDF.

* Ticket : #297
* Financé par le Conseil départemental du Calvados https://www.calvados.fr

![image](https://user-images.githubusercontent.com/3492210/187254136-2413a051-9c2c-42da-b17f-794b4e2b67a7.png)
