### PR TITLE
[Bugfix] Le compte communal abrégé fait 6 caractères (les 6 derniers) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* bugfix - Correction du compte communal abrégé affiché dans les relevés
+
 ## 1.17.0 - 2022-11-25
 
 * Server - Ajout de la carte au relevé parcellaire

--- a/cadastre/cadastre_export.py
+++ b/cadastre/cadastre_export.py
@@ -148,7 +148,7 @@ class CadastreExport:
         Set parameters for given comptecommunal
         """
         # List of templates
-        compte_communal_abrev = compte_communal[9:]
+        compte_communal_abrev = compte_communal[-6:]
         self.composerTemplates = {
             'header1': {
                 'names': ['annee', 'ccodep', 'ccodir', 'ccocom', 'libcom'],


### PR DESCRIPTION
Le compte communal abrégé affiché dans les relevés doit être la valeur des 6 derniers caractères du champs `comptecommunal` sans l'identifiant de la commune.

Funded by Conseil Départemental du Calvados https://www.calvados.fr