### PR TITLE
Ajout de la colonne EX OM à la table des propriétés baties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Ajout de la colonne EX OM au tableau des propriétés baties
+
 ## 1.18.1 - 2023-09-27
 
 * Corrections SQL

--- a/cadastre/cadastre_export.py
+++ b/cadastre/cadastre_export.py
@@ -249,7 +249,7 @@ class CadastreExport:
             'proprietes_baties_line': {
                 'names': ['section', 'ndeplan', 'ndevoirie', 'adresse', 'coderivoli', 'bat', 'ent', 'niv', 'ndeporte',
                           'numeroinvar', 'star', 'meval', 'af', 'natloc', 'cat', 'revenucadastral', 'coll', 'natexo',
-                          'anret', 'andeb', 'fractionrcexo', 'pourcentageexo', 'txom', 'coefreduc', 'rcteom'],
+                          'anret', 'andeb', 'fractionrcexo', 'pourcentageexo', 'txom', 'exom', 'rcteom'],
                 'type': 'sql',
                 'filter': 'comptecommunal',
                 'and': {

--- a/cadastre/templates/proprietes_baties.tpl
+++ b/cadastre/templates/proprietes_baties.tpl
@@ -41,7 +41,7 @@
       <td style="text-align: center;">FRACTION RC EXO</td>
       <td style="text-align: center;">% EXO</td>
       <td style="text-align: center;">TX OM</td>
-      <td style="text-align: center;">COEF REDUC</td>
+      <td style="text-align: center;">EX OM</td>
       <td style="text-align: center;">RC TEOM</td>
     </tr>
   </thead>

--- a/cadastre/templates/proprietes_baties_line.tpl
+++ b/cadastre/templates/proprietes_baties_line.tpl
@@ -22,6 +22,6 @@
       <td align="center">$fractionrcexo</td>
       <td align="center">$pourcentageexo</td>
       <td align="center">$txom</td>
-      <td align="center">$coefreduc</td>
+      <td align="center">$exom</td>
       <td align="right">$rcteom</td>
     </tr>

--- a/cadastre/templates/proprietes_baties_line.tpl.sql
+++ b/cadastre/templates/proprietes_baties_line.tpl.sql
@@ -10,7 +10,7 @@ CASE
   ELSE pt.tse_bipevla
 END AS revenucadastral,
 px.ccolloc AS coll, px.gnextl AS natexo, px.janimp AS anret, px.jandeb AS andeb, Cast(px.rcexba2 * px.pexb / 100 AS numeric(10,2)) AS fractionrcexo,
-px.pexb AS pourcentageexo, l10.gtauom AS txom, '' AS coefreduc, pt.bateom as rcteom
+px.pexb AS pourcentageexo, l10.gtauom AS txom, l10.gimtom AS exom, pt.baeteom as rcteom
 FROM
 $schema"parcelle" p
 INNER JOIN $schema"local00" l ON l.parcelle = p.parcelle

--- a/cadastre/templates/proprietes_baties_line.tpl.sql
+++ b/cadastre/templates/proprietes_baties_line.tpl.sql
@@ -10,7 +10,7 @@ CASE
   ELSE pt.tse_bipevla
 END AS revenucadastral,
 px.ccolloc AS coll, px.gnextl AS natexo, px.janimp AS anret, px.jandeb AS andeb, Cast(px.rcexba2 * px.pexb / 100 AS numeric(10,2)) AS fractionrcexo,
-px.pexb AS pourcentageexo, l10.gtauom AS txom, l10.gimtom AS exom, pt.baeteom as rcteom
+px.pexb AS pourcentageexo, l10.gtauom AS txom, l10.gimtom AS exom, pt.bateom as rcteom
 FROM
 $schema"parcelle" p
 INNER JOIN $schema"local00" l ON l.parcelle = p.parcelle


### PR DESCRIPTION
Affichage de l'Indicateur imposition aux Ordures Ménagères (D, E, V ou blanc) pour les propriétés baties (EX OM) et suppression de la colonne de coefficient de réductio (COEF REDUC).

Funded by SDEC énergie https://www.sdec-energie.fr/
Funded by Conseil Départemental du Calvados https://www.calvados.fr/