### PR TITLE
[SQL] Fix Primary key table proprietaire

### DIFF
--- a/cadastre/scripts/plugin/2012/majic3_formatage_donnees.sql
+++ b/cadastre/scripts/plugin/2012/majic3_formatage_donnees.sql
@@ -818,6 +818,7 @@ CREATE INDEX sufexoneration_suf_idx ON sufexoneration (suf);
 CREATE INDEX idx_proprietaire_ccocom  ON proprietaire (ccocom);
 CREATE INDEX idx_commune_ccocom  ON commune (ccocom);
 CREATE INDEX idx_proprietaire_ccodro  ON proprietaire (ccodro);
+CREATE INDEX idx_proprietaire_proprietaire ON proprietaire (proprietaire);
 CREATE INDEX idx_proprietaire_comptecommunal ON proprietaire (comptecommunal);
 CREATE INDEX idx_local00_parcelle  ON local00 (parcelle);
 CREATE INDEX idx_local00_voie  ON local00 (voie);

--- a/cadastre/scripts/plugin/2013/majic3_formatage_donnees.sql
+++ b/cadastre/scripts/plugin/2013/majic3_formatage_donnees.sql
@@ -823,6 +823,7 @@ CREATE INDEX sufexoneration_suf_idx ON sufexoneration (suf);
 CREATE INDEX idx_proprietaire_ccocom  ON proprietaire (ccocom);
 CREATE INDEX idx_commune_ccocom  ON commune (ccocom);
 CREATE INDEX idx_proprietaire_ccodro  ON proprietaire (ccodro);
+CREATE INDEX idx_proprietaire_proprietaire ON proprietaire (proprietaire);
 CREATE INDEX idx_proprietaire_comptecommunal ON proprietaire (comptecommunal);
 CREATE INDEX idx_local00_parcelle  ON local00 (parcelle);
 CREATE INDEX idx_local00_voie  ON local00 (voie);

--- a/cadastre/scripts/plugin/2014/majic3_formatage_donnees.sql
+++ b/cadastre/scripts/plugin/2014/majic3_formatage_donnees.sql
@@ -824,6 +824,7 @@ CREATE INDEX sufexoneration_suf_idx ON sufexoneration (suf);
 CREATE INDEX idx_proprietaire_ccocom  ON proprietaire (ccocom);
 CREATE INDEX idx_commune_ccocom  ON commune (ccocom);
 CREATE INDEX idx_proprietaire_ccodro  ON proprietaire (ccodro);
+CREATE INDEX idx_proprietaire_proprietaire ON proprietaire (proprietaire);
 CREATE INDEX idx_proprietaire_comptecommunal ON proprietaire (comptecommunal);
 CREATE INDEX idx_local00_parcelle  ON local00 (parcelle);
 CREATE INDEX idx_local00_voie  ON local00 (voie);

--- a/cadastre/scripts/plugin/2015/majic3_formatage_donnees.sql
+++ b/cadastre/scripts/plugin/2015/majic3_formatage_donnees.sql
@@ -831,6 +831,7 @@ CREATE INDEX sufexoneration_suf_idx ON sufexoneration (suf);
 CREATE INDEX idx_proprietaire_ccocom  ON proprietaire (ccocom);
 CREATE INDEX idx_commune_ccocom  ON commune (ccocom);
 CREATE INDEX idx_proprietaire_ccodro  ON proprietaire (ccodro);
+CREATE INDEX idx_proprietaire_proprietaire ON proprietaire (proprietaire);
 CREATE INDEX idx_proprietaire_comptecommunal ON proprietaire (comptecommunal);
 CREATE INDEX idx_local00_parcelle  ON local00 (parcelle);
 CREATE INDEX idx_local00_voie  ON local00 (voie);

--- a/cadastre/scripts/plugin/2016/majic3_formatage_donnees.sql
+++ b/cadastre/scripts/plugin/2016/majic3_formatage_donnees.sql
@@ -831,6 +831,7 @@ CREATE INDEX sufexoneration_suf_idx ON sufexoneration (suf);
 CREATE INDEX idx_proprietaire_ccocom  ON proprietaire (ccocom);
 CREATE INDEX idx_commune_ccocom  ON commune (ccocom);
 CREATE INDEX idx_proprietaire_ccodro  ON proprietaire (ccodro);
+CREATE INDEX idx_proprietaire_proprietaire ON proprietaire (proprietaire);
 CREATE INDEX idx_proprietaire_comptecommunal ON proprietaire (comptecommunal);
 CREATE INDEX idx_local00_parcelle  ON local00 (parcelle);
 CREATE INDEX idx_local00_voie  ON local00 (voie);

--- a/cadastre/scripts/plugin/2017/majic3_formatage_donnees.sql
+++ b/cadastre/scripts/plugin/2017/majic3_formatage_donnees.sql
@@ -912,6 +912,7 @@ CREATE INDEX sufexoneration_suf_idx ON sufexoneration (suf);
 CREATE INDEX idx_proprietaire_ccocom  ON proprietaire (ccocom);
 CREATE INDEX idx_commune_ccocom  ON commune (ccocom);
 CREATE INDEX idx_proprietaire_ccodro  ON proprietaire (ccodro);
+CREATE INDEX idx_proprietaire_proprietaire ON proprietaire (proprietaire);
 CREATE INDEX idx_proprietaire_comptecommunal ON proprietaire (comptecommunal);
 CREATE INDEX idx_local00_parcelle  ON local00 (parcelle);
 CREATE INDEX idx_local00_voie  ON local00 (voie);

--- a/cadastre/scripts/plugin/2018/majic3_formatage_donnees.sql
+++ b/cadastre/scripts/plugin/2018/majic3_formatage_donnees.sql
@@ -955,6 +955,7 @@ CREATE INDEX sufexoneration_suf_idx ON sufexoneration (suf);
 CREATE INDEX idx_proprietaire_ccocom  ON proprietaire (ccocom);
 CREATE INDEX idx_commune_ccocom  ON commune (ccocom);
 CREATE INDEX idx_proprietaire_ccodro  ON proprietaire (ccodro);
+CREATE INDEX idx_proprietaire_proprietaire ON proprietaire (proprietaire);
 CREATE INDEX idx_proprietaire_comptecommunal ON proprietaire (comptecommunal);
 CREATE INDEX idx_local00_parcelle  ON local00 (parcelle);
 CREATE INDEX idx_local00_voie  ON local00 (voie);

--- a/cadastre/scripts/plugin/2019/majic3_formatage_donnees.sql
+++ b/cadastre/scripts/plugin/2019/majic3_formatage_donnees.sql
@@ -1055,6 +1055,7 @@ CREATE INDEX sufexoneration_suf_idx ON sufexoneration (suf);
 CREATE INDEX idx_proprietaire_ccocom  ON proprietaire (ccocom);
 CREATE INDEX idx_commune_ccocom  ON commune (ccocom);
 CREATE INDEX idx_proprietaire_ccodro  ON proprietaire (ccodro);
+CREATE INDEX idx_proprietaire_proprietaire ON proprietaire (proprietaire);
 CREATE INDEX idx_proprietaire_comptecommunal ON proprietaire (comptecommunal);
 CREATE INDEX idx_local00_parcelle  ON local00 (parcelle);
 CREATE INDEX idx_local00_voie  ON local00 (voie);

--- a/cadastre/scripts/plugin/2020/majic3_formatage_donnees.sql
+++ b/cadastre/scripts/plugin/2020/majic3_formatage_donnees.sql
@@ -1056,6 +1056,7 @@ CREATE INDEX sufexoneration_suf_idx ON sufexoneration (suf);
 CREATE INDEX idx_proprietaire_ccocom  ON proprietaire (ccocom);
 CREATE INDEX idx_commune_ccocom  ON commune (ccocom);
 CREATE INDEX idx_proprietaire_ccodro  ON proprietaire (ccodro);
+CREATE INDEX idx_proprietaire_proprietaire ON proprietaire (proprietaire);
 CREATE INDEX idx_proprietaire_comptecommunal ON proprietaire (comptecommunal);
 CREATE INDEX idx_local00_parcelle  ON local00 (parcelle);
 CREATE INDEX idx_local00_voie  ON local00 (voie);

--- a/cadastre/scripts/plugin/2021/majic3_formatage_donnees.sql
+++ b/cadastre/scripts/plugin/2021/majic3_formatage_donnees.sql
@@ -1056,6 +1056,7 @@ CREATE INDEX sufexoneration_suf_idx ON sufexoneration (suf);
 CREATE INDEX idx_proprietaire_ccocom  ON proprietaire (ccocom);
 CREATE INDEX idx_commune_ccocom  ON commune (ccocom);
 CREATE INDEX idx_proprietaire_ccodro  ON proprietaire (ccodro);
+CREATE INDEX idx_proprietaire_proprietaire ON proprietaire (proprietaire);
 CREATE INDEX idx_proprietaire_comptecommunal ON proprietaire (comptecommunal);
 CREATE INDEX idx_local00_parcelle  ON local00 (parcelle);
 CREATE INDEX idx_local00_voie  ON local00 (voie);

--- a/cadastre/scripts/plugin/2022/majic3_formatage_donnees.sql
+++ b/cadastre/scripts/plugin/2022/majic3_formatage_donnees.sql
@@ -1056,6 +1056,7 @@ CREATE INDEX sufexoneration_suf_idx ON sufexoneration (suf);
 CREATE INDEX idx_proprietaire_ccocom  ON proprietaire (ccocom);
 CREATE INDEX idx_commune_ccocom  ON commune (ccocom);
 CREATE INDEX idx_proprietaire_ccodro  ON proprietaire (ccodro);
+CREATE INDEX idx_proprietaire_proprietaire ON proprietaire (proprietaire);
 CREATE INDEX idx_proprietaire_comptecommunal ON proprietaire (comptecommunal);
 CREATE INDEX idx_local00_parcelle  ON local00 (parcelle);
 CREATE INDEX idx_local00_voie  ON local00 (voie);

--- a/cadastre/scripts/plugin/2023/majic3_formatage_donnees.sql
+++ b/cadastre/scripts/plugin/2023/majic3_formatage_donnees.sql
@@ -1056,6 +1056,7 @@ CREATE INDEX sufexoneration_suf_idx ON sufexoneration (suf);
 CREATE INDEX idx_proprietaire_ccocom  ON proprietaire (ccocom);
 CREATE INDEX idx_commune_ccocom  ON commune (ccocom);
 CREATE INDEX idx_proprietaire_ccodro  ON proprietaire (ccodro);
+CREATE INDEX idx_proprietaire_proprietaire ON proprietaire (proprietaire);
 CREATE INDEX idx_proprietaire_comptecommunal ON proprietaire (comptecommunal);
 CREATE INDEX idx_local00_parcelle  ON local00 (parcelle);
 CREATE INDEX idx_local00_voie  ON local00 (voie);

--- a/cadastre/scripts/plugin/commun_create_metier.sql
+++ b/cadastre/scripts/plugin/commun_create_metier.sql
@@ -535,6 +535,7 @@ CREATE TABLE pevdependances (
 );
 
 CREATE TABLE proprietaire (
+    id serial NOT NULL,
     proprietaire text,
     annee text,
     ccodep text,

--- a/cadastre/scripts/plugin/commun_creation_contraintes.sql
+++ b/cadastre/scripts/plugin/commun_creation_contraintes.sql
@@ -13,7 +13,7 @@ ALTER TABLE [PREFIXE]pevprincipale ADD CONSTRAINT pevprincipale_pk PRIMARY KEY  
 ALTER TABLE [PREFIXE]pevprofessionnelle ADD CONSTRAINT pevprofessionnelle_pk PRIMARY KEY  (pevprofessionnelle);
 ALTER TABLE [PREFIXE]pevlissage ADD CONSTRAINT pevlissage_pk PRIMARY KEY  (pevlissage);
 ALTER TABLE [PREFIXE]pevdependances ADD CONSTRAINT pevdependances_pk PRIMARY KEY  (pevdependances);
-ALTER TABLE [PREFIXE]proprietaire ADD CONSTRAINT proprietaire_pk PRIMARY KEY  (proprietaire);
+ALTER TABLE [PREFIXE]proprietaire ADD CONSTRAINT proprietaire_pk PRIMARY KEY  (id);
 DELETE FROM [PREFIXE]comptecommunal WHERE comptecommunal IS NULL;
 ALTER TABLE [PREFIXE]comptecommunal ADD CONSTRAINT comptecommunal_pk PRIMARY KEY  (comptecommunal);
 ALTER TABLE [PREFIXE]pdl ADD CONSTRAINT pdl_pk PRIMARY KEY  (pdl);

--- a/cadastre/scripts/plugin/edigeo_create_indexes.sql
+++ b/cadastre/scripts/plugin/edigeo_create_indexes.sql
@@ -51,6 +51,8 @@ DROP INDEX IF EXISTS idx_commune_majic_ccocom;
 CREATE INDEX idx_commune_majic_ccocom ON commune_majic (ccocom);
 DROP INDEX IF EXISTS idx_proprietaire_ccodro;
 CREATE INDEX idx_proprietaire_ccodro ON proprietaire (ccodro);
+DROP INDEX IF EXISTS idx_proprietaire_proprietaire;
+CREATE INDEX idx_proprietaire_proprietaire ON proprietaire (proprietaire);
 DROP INDEX IF EXISTS idx_proprietaire_comptecommunal;
 CREATE INDEX idx_proprietaire_comptecommunal ON proprietaire (comptecommunal);
 DROP INDEX IF EXISTS idx_local00_parcelle;
@@ -69,4 +71,3 @@ DROP INDEX IF EXISTS idx_parcelle_voie;
 CREATE INDEX idx_parcelle_voie ON parcelle (voie);
 DROP INDEX IF EXISTS idx_parcelle_comptecommunal;
 CREATE INDEX idx_parcelle_comptecommunal ON parcelle (comptecommunal);
-

--- a/cadastre/scripts/plugin/edigeo_drop_indexes.sql
+++ b/cadastre/scripts/plugin/edigeo_drop_indexes.sql
@@ -110,6 +110,7 @@ DROP INDEX IF EXISTS idx_proprietaire_ccocom;
 DROP INDEX IF EXISTS idx_commune_ccocom;
 DROP INDEX IF EXISTS idx_commune_majic_ccocom;
 DROP INDEX IF EXISTS idx_proprietaire_ccodro;
+DROP INDEX IF EXISTS idx_proprietaire_proprietaire;
 DROP INDEX IF EXISTS idx_proprietaire_comptecommunal;
 DROP INDEX IF EXISTS idx_local00_parcelle;
 DROP INDEX IF EXISTS idx_local00_voie;

--- a/cadastre/scripts/plugin/majic3_drop_indexes.sql
+++ b/cadastre/scripts/plugin/majic3_drop_indexes.sql
@@ -34,6 +34,7 @@ DROP INDEX IF EXISTS idx_proprietaire_ccocom;
 DROP INDEX IF EXISTS idx_commune_ccocom;
 DROP INDEX IF EXISTS idx_majic_commune_ccocom;
 DROP INDEX IF EXISTS idx_proprietaire_ccodro;
+DROP INDEX IF EXISTS idx_proprietaire_proprietaire;
 DROP INDEX IF EXISTS idx_proprietaire_comptecommunal;
 DROP INDEX IF EXISTS idx_local00_parcelle;
 DROP INDEX IF EXISTS idx_local00_voie;


### PR DESCRIPTION
Il arrive que dans un dépratement pour une division, un proprietaire apparaisse plusieurs fois. La contrainte d'unicité est donc caduque pour le cahmps `proprietaire` de la table `proprietaire`.

je propose d'ajouter une clé primaire de type serial et un index sur le champs proprietaire.

Funded by [Établissement Public Foncier Hauts De France](https://epf-hdf.fr/)
