### PR TITLE
[SQL] Ajout d'un idex sur le champ voie de la table parcelle_info

### DIFF
--- a/cadastre/scripts/plugin/edigeo_create_table_parcelle_info_majic.sql
+++ b/cadastre/scripts/plugin/edigeo_create_table_parcelle_info_majic.sql
@@ -111,6 +111,7 @@ DROP INDEX jj;
 ALTER TABLE [PREFIXE]parcelle_info ADD CONSTRAINT parcelle_info_pk PRIMARY KEY (ogc_fid);
 CREATE INDEX parcelle_info_geom_idx ON [PREFIXE]parcelle_info USING gist (geom);
 CREATE INDEX parcelle_info_geo_section_idx ON [PREFIXE]parcelle_info (geo_section);
+CREATE INDEX parcelle_info_voie_idx ON [PREFIXE]parcelle_info (voie);
 CREATE INDEX parcelle_info_comptecommunal_idx ON [PREFIXE]parcelle_info (comptecommunal);
 CREATE INDEX parcelle_info_codecommune_idx ON [PREFIXE]parcelle_info (codecommune );
 CREATE INDEX parcelle_info_geo_parcelle_idx ON [PREFIXE]parcelle_info (geo_parcelle );

--- a/cadastre/scripts/plugin/edigeo_create_table_parcelle_info_simple.sql
+++ b/cadastre/scripts/plugin/edigeo_create_table_parcelle_info_simple.sql
@@ -31,6 +31,7 @@ ON c.geo_commune = SUBSTRING(gp.geo_parcelle,1,6)
 ALTER TABLE [PREFIXE]parcelle_info ADD CONSTRAINT parcelle_info_pk PRIMARY KEY (ogc_fid);
 CREATE INDEX parcelle_info_geom_idx ON [PREFIXE]parcelle_info USING gist (geom);
 CREATE INDEX parcelle_info_geo_section_idx ON [PREFIXE]parcelle_info (geo_section);
+CREATE INDEX parcelle_info_voie_idx ON [PREFIXE]parcelle_info (voie);
 CREATE INDEX parcelle_info_codecommune_idx ON [PREFIXE]parcelle_info (codecommune );
 CREATE INDEX parcelle_info_geo_parcelle_idx ON [PREFIXE]parcelle_info (geo_parcelle );
 


### PR DESCRIPTION
N'ayant pas d'index sur le champs `voie` de la table `parcelle_info`, les rechercehs sur ce champs était très lente.

Funded by [Conseil Départemental du Calvados](https://www.calvados.fr)