### PR TITLE
Import - Amélioration des performances pour l'EDIGEO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Import - Amélioration des performances pour l'EDIGEO
+  L'import des données EDIGEO via ogr2ogr n'utilisait plus l'option `PG_USE_COPY`
+
 ## 1.18.1 - 2023-09-27
 
 * Corrections SQL

--- a/cadastre/cadastre_import.py
+++ b/cadastre/cadastre_import.py
@@ -1402,7 +1402,8 @@ class cadastreImport(QObject):
                     '-lco', 'PG_USE_COPY=YES',
                     '-nlt', 'GEOMETRY',
                     '-gt', '50000',
-                    '--config', 'OGR_EDIGEO_CREATE_LABEL_LAYERS', 'NO'
+                    '--config', 'OGR_EDIGEO_CREATE_LABEL_LAYERS', 'NO',
+                    '--config', 'PG_USE_COPY', 'YES',
                 ]
                 # -c client_encoding=latin1
 


### PR DESCRIPTION
Ré-application de `PG_USE_COPY` pour l'import des données via ogr2ogr en basculant l'option sur `--config`

Cela corrige une régression importante sur les performances d'import pour des gros volumes de données

cc @MaelREBOUX @Gustry @landryb 