### PR TITLE
Fix tarfile security issue

### DIFF
--- a/cadastre/cadastre_import.py
+++ b/cadastre/cadastre_import.py
@@ -1009,7 +1009,12 @@ class cadastreImport(QObject):
                 for z in tarFileListA:
                     with tarfile.open(z) as t:
                         try:
-                            t.extractall(os.path.join(self.edigeoPlainDir, 'tar_%s' % i))
+                            # See https://docs.python.org/3.8/library/tarfile.html#tarfile.TarFile.extractall
+                            # See https://peps.python.org/pep-0706/
+                            t.extractall(
+                                os.path.join(self.edigeoPlainDir, 'tar_%s' % i),
+                                filter='data',
+                            )
                         except tarfile.ReadError:
                             # Issue GitHub #339
                             self.go = False


### PR DESCRIPTION
Opening untrunsted tarfile is a potential security issue:

* See https://github.com/python/cpython/issues/45385
* See https://peps.python.org/pep-0706/

Since tarfiles used in cadastre are downloaded from external site, they should be considered as untrusted.

The issue is solved by adding the parameter `fllter='data'` in the `extractall` method: see See https://docs.python.org/3.8/library/tarfile.html#tarfile.TarFile.extractall.

**IMPORTANT NOTE**: the `filter` parameter require python 3.8 minimum.  

**Lower version of python are DEPRECATED and should not be supported anymore**, since they present a secuity risk.


