### PR TITLE
Fixes pour qt6

### DIFF
--- a/cadastre/cadastre_loading.py
+++ b/cadastre/cadastre_loading.py
@@ -633,7 +633,7 @@ class CadastreLoading(QObject):
                 # Enable/Disable layer
                 if not q_layer['active']:
                     # noinspection PyUnresolvedReferences
-                    node_layer.setItemVisibilityChecked(Qt.CheckState.Unchecked)
+                    node_layer.setItemVisibilityChecked(False)
             else:
                 # Move layer to Cadastre group
                 g1.insertChildNode(-1, node_layer)

--- a/cadastre/dialogs/cadastre_load_dialog.py
+++ b/cadastre/dialogs/cadastre_load_dialog.py
@@ -61,8 +61,8 @@ class CadastreLoadDialog(QDialog, LOAD_FORM_CLASS):
         self.getStyleList()
 
         # Signals/Slot Connections
-        self.liDbType.currentIndexChanged[str].connect(self.qc.updateConnectionList)
-        self.liDbConnection.currentIndexChanged[str].connect(self.qc.updateSchemaList)
+        self.liDbType.currentIndexChanged.connect(self.qc.updateConnectionList)
+        self.liDbConnection.currentIndexChanged.connect(self.qc.updateSchemaList)
         self.btProcessLoading.clicked.connect(self.onProcessLoadingClicked)
         self.ql.cadastreLoadingFinished.connect(self.onLoadingEnd)
 

--- a/cadastre/dialogs/custom_qcompleter.py
+++ b/cadastre/dialogs/custom_qcompleter.py
@@ -3,7 +3,7 @@ __license__ = "GPL version 3"
 __email__ = "info@3liz.org"
 
 from qgis.PyQt.QtCore import (
-    QRegExp,
+    QRegularExpression,
     QSortFilterProxyModel,
     QStringListModel,
     Qt,
@@ -35,12 +35,11 @@ class CustomQCompleter(QCompleter):
         if not self.usingOriginalModel:
             self.filterProxyModel.setSourceModel(self.source_model)
 
-        pattern = QRegExp(self.local_completion_prefix,
-                          Qt.CaseSensitivity.CaseInsensitive,
-                          QRegExp.FixedString
+        pattern = QRegularExpression(self.local_completion_prefix,
+                          QRegularExpression.CaseInsensitiveOption
                           )
 
-        self.filterProxyModel.setFilterRegExp(pattern)
+        self.filterProxyModel.setFilterRegularExpression(pattern)
 
     def splitPath(self, path):
         self.local_completion_prefix = path

--- a/cadastre/dialogs/import_dialog.py
+++ b/cadastre/dialogs/import_dialog.py
@@ -56,8 +56,8 @@ class CadastreImportDialog(QDialog, IMPORT_FORM_CLASS):
             self.btCreateNewSpatialiteDb.setEnabled(False)
 
         # Signals/Slot Connections
-        self.liDbType.currentIndexChanged[str].connect(self.qc.updateConnectionList)
-        self.liDbConnection.currentIndexChanged[str].connect(self.qc.updateSchemaList)
+        self.liDbType.currentIndexChanged.connect(self.qc.updateConnectionList)
+        self.liDbConnection.currentIndexChanged.connect(self.qc.updateSchemaList)
         self.btDbCreateSchema.clicked.connect(self.createSchema)
         self.btCreateNewSpatialiteDb.clicked.connect(self.qc.createNewSpatialiteDatabase)
         self.btProcessImport.clicked.connect(self.processImport)

--- a/cadastre/dialogs/search_dialog.py
+++ b/cadastre/dialogs/search_dialog.py
@@ -308,7 +308,7 @@ class CadastreSearchDialog(QDockWidget, SEARCH_FORM_CLASS):
 
                 # when the user chooses in the list
                 slot = partial(self.onNonSearchItemChoose, key)
-                control.currentIndexChanged[str].connect(slot)
+                control.currentIndexChanged.connect(slot)
 
                 # when the user reset the entered value
                 control = item['resetWidget']


### PR DESCRIPTION
<!-- Add "fix" in front of # if it fixes the ticket or do nothing to only mention it -->
* fix #490


testé ici:
- charger une bdd postgis existante, les couches sont bien ajoutées au layertree
- ouvrir les dialogues de configuration/import
- fiche d'information parcelle fonctionne
- selection d'une commune/section/parcelle a l'air OK

non testé:
- import d'un jeu de donnée dans une nouvelle base que ce soit spatialite ou postgis
- pas encore pu tester
non fonctionnel:
- l'export d'un RP en PDF se fait dans `/tmp/cad_export_ms2fw40k/` et le pdf est vide/blanc
- l'autocompletion sur les noms de proprietaire echoue (7f723d7 a corriger)
```
              QRegularExpression.CaseInsensitiveOption
             AttributeError: type object 'QRegularExpression' has no attribute 'CaseInsensitiveOption'
```