### PR TITLE
import: ignore files ending with '.pdf' or '.PDF'

### DIFF
--- a/cadastre/cadastre_import.py
+++ b/cadastre/cadastre_import.py
@@ -461,6 +461,10 @@ class cadastreImport(QObject):
                         file_path = os.path.join(root, file_sub_path)
                         maj_list.append(file_path)
 
+                        # ignore PDF files
+                        if file_path.endswith(".pdf") or file_path.endswith(".PDF"):
+                            continue
+
                         # avoid topo, since direction is not used in TOPO
                         if table == 'topo':
                             continue


### PR DESCRIPTION
i've tried with regexes for https://github.com/3liz/QgisCadastrePlugin/blob/master/cadastre/definitions.py#L7 but `BATI.*(?!PDF$|pdf$)` didnt exclude them.

fixes #481 - dunno if sometimes ppl get doc files instead of PDFs (i know i've had some in the distant past)