### PR TITLE
drop duplicate TOPO entry in option form (#483)

### DIFF
--- a/cadastre/forms/cadastre_option_form.ui
+++ b/cadastre/forms/cadastre_option_form.ui
@@ -98,13 +98,6 @@
               </property>
              </widget>
             </item>
-            <item row="6" column="0">
-             <widget class="QLabel" name="label_10">
-              <property name="text">
-               <string>TOPO</string>
-              </property>
-             </widget>
-            </item>
             <item row="0" column="0">
              <widget class="QLabel" name="label">
               <property name="text">
@@ -147,13 +140,6 @@
               </property>
              </widget>
             </item>
-            <item row="6" column="2">
-             <widget class="QLineEdit" name="lineEdit">
-              <property name="text">
-               <string>TOPO</string>
-              </property>
-             </widget>
-            </item>
             <item row="3" column="0">
              <widget class="QLabel" name="label_4">
               <property name="text">
@@ -168,14 +154,14 @@
               </property>
              </widget>
             </item>
-            <item row="7" column="2">
+            <item row="6" column="2">
              <widget class="QLineEdit" name="inMajicTopo">
               <property name="text">
                <string>TOPO</string>
               </property>
              </widget>
             </item>
-            <item row="7" column="0">
+            <item row="6" column="0">
              <widget class="QLabel" name="label_2">
               <property name="text">
                <string>TOPO</string>
@@ -309,7 +295,6 @@
   <tabstop>inMajicNbati</tabstop>
   <tabstop>inMajicPdl</tabstop>
   <tabstop>inMajicProp</tabstop>
-  <tabstop>lineEdit</tabstop>
   <tabstop>inMajicTopo</tabstop>
   <tabstop>inComposerTemplateFile</tabstop>
   <tabstop>btComposerTemplateFile</tabstop>


### PR DESCRIPTION
one was added in 7601616 and the previous FANTOIR one was renamed to TOPO in 275d4d8

fixes #483 

i've checked that the regexp entered in (the now-single TOPO field in) the UI ended up in the right config key in QGIS3.ini:
```
~/.local/share/QGIS/QGIS3/profiles/default/ $grep ^regex QGIS/*.ini    
QGIS/QGIS3.ini:regexBati=BATI
QGIS/QGIS3.ini:regexLotLocal=LLOC|D166
QGIS/QGIS3.ini:regexNbati=NBAT
QGIS/QGIS3.ini:regexPdl=PDL
QGIS/QGIS3.ini:regexProp=PROP
QGIS/QGIS3.ini:regexTopo=TOPOAA

```