### PR TITLE
dnatlc est vide/non renseigné depuis le millésime 2024

### DIFF
--- a/cadastre/templates/parcelle_info_locaux.sql
+++ b/cadastre/templates/parcelle_info_locaux.sql
@@ -21,7 +21,7 @@ FROM (
         '<td>' || l.invar || '</td>' ||
         '<td>' || dteloc_lib || '</td>' ||
         '<td>' || cconlc_lib || '</td>' ||
-        '<td>' || dnatlc_lib || '</td>' ||
+        '<td>' || Coalesce(dnatlc_lib, '') || '</td>' ||
         '<td>' || COALESCE(cast(l10.jdatat AS text), '') || '</td>' ||
         '<td>' || Coalesce(cast(l10.jannat AS text), '') || '</td>' ||
         '<td>' ||

--- a/cadastre/templates/parcelle_info_locaux_detail.sql
+++ b/cadastre/templates/parcelle_info_locaux_detail.sql
@@ -254,7 +254,7 @@ SELECT
         '<p>' ||
         '<b>Type: </b>' ||  l10_type_local ||
         '<br/><b>Nature: </b>' ||  l10_nature_local ||
-        '<br/><b>Occupation: </b>' ||  l10_nature_occupation ||
+        '<br/><b>Occupation: </b>' ||  Coalesce(l10_nature_occupation, '-') ||
         '<br/><b>Construction: </b>' ||  l10_nature_construction_particuliere ||
         '<br/><b>Année de construction: </b>' ||  l10_annee_construction ||
         '<br/><b>Niveaux: </b>' ||  l10_nombre_niveaux ||


### PR DESCRIPTION
si la valeur est NULL, alors il faut utiliser coalesce, sinon la requete SQL ne renverra rien.

fixes #495

