### PR TITLE
Correction du remplissage de la table parcelle_info lors d'un import spatialite

### DIFF
--- a/cadastre/cadastre_common_base.py
+++ b/cadastre/cadastre_common_base.py
@@ -270,6 +270,7 @@ def postgisToSpatialite(sql: str, targetSrid: str = '2154') -> str:
         {'in': r'serial', 'out': 'INTEGER PRIMARY KEY AUTOINCREMENT'},
         {'in': r'string_agg', 'out': 'group_concat'},
         {'in': r'current_schema::text, ', 'out': ''},
+        {'in': r'add column if not exists', 'out': 'add column'},
         {'in': r'substring', 'out': 'SUBSTR'},
         {'in': r"(to_char\()([^']+) *, *'[09]+' *\)", 'out': r"CAST(\2 AS TEXT)"},
         {'in': r"(to_number\()([^']+) *, *'[09]+' *\)", 'out': r"CAST(\2 AS float)"},

--- a/cadastre/cadastre_import.py
+++ b/cadastre/cadastre_import.py
@@ -396,10 +396,18 @@ class cadastreImport(QObject):
             )
 
             # Ajout de la table parcelle_info
+            script_list.append(
+                {
+                    'title': 'Ajout des champs a la table parcelle_info',
+                    'script': '%s' % os.path.join(self.pScriptDir, 'edigeo_ajout_champs_parcelle_info_majic.sql'),
+                    'divide': True,
+                }
+            )
+
             replace_dict['SRID'] = self.targetSrid
             script_list.append(
                 {
-                    'title': 'Ajout de la table parcelle_info',
+                    'title': 'Remplissage de la table parcelle_info',
                     'script': '%s' % os.path.join(self.pScriptDir, 'edigeo_create_table_parcelle_info_majic.sql'),
                     'divide': False
                 }
@@ -875,7 +883,15 @@ class cadastreImport(QObject):
             replaceDict['SRID'] = self.targetSrid
             scriptList.append(
                 {
-                    'title': 'Ajout de la table parcelle_info',
+                    'title': 'Ajout des champs a la table parcelle_info',
+                    'script': '%s' % os.path.join(self.pScriptDir, 'edigeo_ajout_champs_parcelle_info_majic.sql'),
+                    'divide': True,
+                }
+            )
+
+            scriptList.append(
+                {
+                    'title': 'Remplissage de la table parcelle_info',
                     'script': '%s' % os.path.join(self.pScriptDir, 'edigeo_create_table_parcelle_info_majic.sql')
                 }
             )
@@ -883,7 +899,7 @@ class cadastreImport(QObject):
             replaceDict['SRID'] = self.targetSrid
             scriptList.append(
                 {
-                    'title': 'Ajout de la table parcelle_info',
+                    'title': 'Remplissage de la table parcelle_info',
                     'script': '%s' % os.path.join(self.pScriptDir, 'edigeo_create_table_parcelle_info_simple.sql')
                 }
             )
@@ -1393,7 +1409,7 @@ class cadastreImport(QObject):
                         self.qc.updateLog("<b>Erreur rencontrée pour la requête:</b> <p>%s</p>" % sql)
                         self.qc.updateLog("<b>Erreur </b> <p>%s</p>" % e.msg)
                 except sqlite.OperationalError as e:
-                    if not re.search(r'CREATE INDEX ', sql, re.IGNORECASE):
+                    if not re.search(r'CREATE INDEX ', sql, re.IGNORECASE) and 'duplicate column name' not in e.args[0]:
                         self.go = False
                         self.qc.updateLog("<b>Erreur rencontrée pour la requête:</b> <p>%s</p>" % sql)
                         self.qc.updateLog("<b>Erreur </b> <p>%s</p>" % format(e))

--- a/cadastre/scripts/plugin/edigeo_ajout_champs_parcelle_info_majic.sql
+++ b/cadastre/scripts/plugin/edigeo_ajout_champs_parcelle_info_majic.sql
@@ -1,0 +1,22 @@
+-- Ajout des champs specifiques a la version MAJIC de la table parcelle_info
+
+ALTER TABLE ${PREFIXE}parcelle_info ADD COLUMN IF NOT EXISTS parcelle_batie text;
+ALTER TABLE ${PREFIXE}parcelle_info ADD COLUMN IF NOT EXISTS adresse text;
+ALTER TABLE ${PREFIXE}parcelle_info ADD COLUMN IF NOT EXISTS urbain text;
+ALTER TABLE ${PREFIXE}parcelle_info ADD COLUMN IF NOT EXISTS code text;
+ALTER TABLE ${PREFIXE}parcelle_info ADD COLUMN IF NOT EXISTS comptecommunal text;
+ALTER TABLE ${PREFIXE}parcelle_info ADD COLUMN IF NOT EXISTS voie text;
+ALTER TABLE ${PREFIXE}parcelle_info ADD COLUMN IF NOT EXISTS proprietaire text;
+ALTER TABLE ${PREFIXE}parcelle_info ADD COLUMN IF NOT EXISTS proprietaire_info text;
+
+CREATE INDEX IF NOT EXISTS parcelle_info_voie_substr_idx ON ${PREFIXE}parcelle_info ((substr(voie, 1, 6) || substr(voie, 12, 4)));
+CREATE INDEX IF NOT EXISTS parcelle_info_comptecommunal_idx ON ${PREFIXE}parcelle_info (comptecommunal);
+
+COMMENT ON COLUMN parcelle_info.parcelle_batie IS 'Indique si la parcelle est bâtie ou non (issu du champ parcelle.gparbat)';
+COMMENT ON COLUMN parcelle_info.adresse IS 'Adresse de la parcelle';
+COMMENT ON COLUMN parcelle_info.urbain IS 'Déclare si la parcelle est urbaine ou non';
+COMMENT ON COLUMN parcelle_info.code IS 'Code de la parcelle (6 caractères, ex: AB0001)';
+COMMENT ON COLUMN parcelle_info.comptecommunal IS 'Compte communal du propriétaire';
+COMMENT ON COLUMN parcelle_info.voie IS 'Code de la voie (lien avec voie)';
+COMMENT ON COLUMN parcelle_info.proprietaire IS 'Information sur les propriétaires: code DNUPER, nom, et type. Les informations sont séparées par | entre propriétaires.';
+COMMENT ON COLUMN parcelle_info.proprietaire_info IS 'Informations détaillées sur les propriétaires bis: code DNUPER, adresse, date et lieu de naissance. Les informations sont séparées par | entre propriétaires.';

--- a/cadastre/scripts/plugin/edigeo_create_table_parcelle_info_majic.sql
+++ b/cadastre/scripts/plugin/edigeo_create_table_parcelle_info_majic.sql
@@ -1,19 +1,5 @@
 BEGIN;
 
--- Ajout des champs specifiques a la version MAJIC de la table parcelle_info
-
-ALTER TABLE ${PREFIXE}parcelle_info ADD COLUMN IF NOT EXISTS parcelle_batie text;
-ALTER TABLE ${PREFIXE}parcelle_info ADD COLUMN IF NOT EXISTS adresse text;
-ALTER TABLE ${PREFIXE}parcelle_info ADD COLUMN IF NOT EXISTS urbain text;
-ALTER TABLE ${PREFIXE}parcelle_info ADD COLUMN IF NOT EXISTS code text;
-ALTER TABLE ${PREFIXE}parcelle_info ADD COLUMN IF NOT EXISTS comptecommunal text;
-ALTER TABLE ${PREFIXE}parcelle_info ADD COLUMN IF NOT EXISTS voie text;
-ALTER TABLE ${PREFIXE}parcelle_info ADD COLUMN IF NOT EXISTS proprietaire text;
-ALTER TABLE ${PREFIXE}parcelle_info ADD COLUMN IF NOT EXISTS proprietaire_info text;
-
-CREATE INDEX IF NOT EXISTS parcelle_info_voie_substr_idx ON ${PREFIXE}parcelle_info ((substr(voie, 1, 6) || substr(voie, 12, 4)));
-CREATE INDEX IF NOT EXISTS parcelle_info_comptecommunal_idx ON ${PREFIXE}parcelle_info (comptecommunal);
-
 -- Insertion pour le lot ${LOT}
 
 INSERT INTO ${PREFIXE}parcelle_info
@@ -80,16 +66,5 @@ c.libcom, p.ccocom, gp.geom, p.dcntpa, v.libvoi, p.dnvoiri, v.natvoi,
 p.comptecommunal, p.cconvo, p.voie, p.dvoilib, p.gurbpa, p.gparbat,
 ccosec, dnupla
 ;
-
-
-
-COMMENT ON COLUMN parcelle_info.parcelle_batie IS 'Indique si la parcelle est bâtie ou non (issu du champ parcelle.gparbat)';
-COMMENT ON COLUMN parcelle_info.adresse IS 'Adresse de la parcelle';
-COMMENT ON COLUMN parcelle_info.urbain IS 'Déclare si la parcelle est urbaine ou non';
-COMMENT ON COLUMN parcelle_info.code IS 'Code de la parcelle (6 caractères, ex: AB0001)';
-COMMENT ON COLUMN parcelle_info.comptecommunal IS 'Compte communal du propriétaire';
-COMMENT ON COLUMN parcelle_info.voie IS 'Code de la voie (lien avec voie)';
-COMMENT ON COLUMN parcelle_info.proprietaire IS 'Information sur les propriétaires: code DNUPER, nom, et type. Les informations sont séparées par | entre propriétaires.';
-COMMENT ON COLUMN parcelle_info.proprietaire_info IS 'Informations détaillées sur les propriétaires bis: code DNUPER, adresse, date et lieu de naissance. Les informations sont séparées par | entre propriétaires.';
 
 COMMIT;


### PR DESCRIPTION
sqlite ne supporte pas 'ALTER TABLE table ADD COLUMN IF NOT EXISTS', donc:
- on remplace la construction par 'ADD COLUMN' dans postgisToSpatialite
- on sépare l'ajout des champs spécifiques majic dans un script sql distinct
- enfin, on ignore l'exception sqlite3.OperationalError si elle contient 'duplicate column name'

<!-- Add "fix" in front of # if it fixes the ticket or do nothing to only mention it -->
* Ticket : fix #508

@mdouchin je veux bien une bonne relecture sur la logique, j'ai testé:
- import dans spatialite vierge -> la table existe, les champs majic sont ajoutés, la table est remplie (les INSERT INTO se font)
- reimport dans spatialite existant -> la table existante est vidée pour le lot correspondant, la table est bien remplie (les INSERT INTO se font)
- import d'un lot dans un schéma postgis existant avec une db deja remplie par d'autres lots -> les INSERT INTO se font

nota: je ne teste pas du tout les cas _import d'edigeo sans majic_ ou _import de majic seul puis import d'edigeo_