### PR TITLE
Update majic3_formatage_donnees.sql to ignore dlign5 if in france

### DIFF
--- a/cadastre/scripts/plugin/2025/majic3_formatage_donnees.sql
+++ b/cadastre/scripts/plugin/2025/majic3_formatage_donnees.sql
@@ -793,7 +793,7 @@ SELECT DISTINCT ON (ccodep,ccocom,dnupro,dnulp,dnuper)
   CASE WHEN trim(SUBSTRING(tmp,120,1))='' THEN NULL ELSE trim(SUBSTRING(tmp,120,1)) END AS gtyp6,
   SUBSTRING(tmp,121,30) AS dlign3,
   SUBSTRING(tmp,151,36) AS dlign4,
-  CASE WHEN trim(SUBSTRING(tmp,249,1))='' THEN PRINTF('%.*c', 30, ' ') ELSE SUBSTRING(tmp,187,30) END AS dlign5,
+  CASE WHEN trim(SUBSTRING(tmp,249,1))='' THEN '                              ' ELSE SUBSTRING(tmp,187,30) END AS dlign5,
   SUBSTRING(tmp,217,32) AS dlign6,
   SUBSTRING(tmp,249,3) AS ccopay,
   SUBSTRING(tmp,252,2) AS ccodep1a2,


### PR DESCRIPTION
<!-- Add "fix" in front of # if it fixes the ticket or do nothing to only mention it -->
fix #511 
 
L'option choisie ici est d'ignorer dlign5 pour les adresse en France et de l'utiliser uniquement pour les adresses à l'étranger.
Ainsi on retombe sur le comportement que l'on avait avec des fichiers MAJIC antérieur à 2025. J'ai conscience de cette option est discutable, mais elle a le mérite de faire une première proposition.

Pour regarder si on est en France, j'ai regarder le caractère 249 du fichier qui semble être vide pour la France mais pas pour les autres pays. S'il y a mieux, je suis preneur !

Le choix a été fait, pour la France, de garder une string de longueur 30 vide pour dlign5 pour imiter la lecture du fichier MAJIC, ne sachant pas le traitement que subie cette string ultérieurement. J'ai aussi conscience que ce choix est discutable.