### PR TITLE
Update edigeo_create_table_parcelle_info_majic.sql

### DIFF
--- a/cadastre/scripts/plugin/edigeo_create_table_parcelle_info_majic.sql
+++ b/cadastre/scripts/plugin/edigeo_create_table_parcelle_info_majic.sql
@@ -17,7 +17,7 @@ CASE
     ELSE 'Non'
 END AS parcelle_batie,
 CASE
-        WHEN v.libvoi IS NOT NULL THEN trim(ltrim(p.dnvoiri, '0') || ' ' || trim(Coalesce(v.natvoi, '')) || v.libvoi)
+        WHEN v.libvoi IS NOT NULL THEN replace(trim(ltrim(p.dnvoiri, '0')) || ' ' || trim((Coalesce(v.natvoi, ''))) || ' ' || trim(v.libvoi), '  ', ' ')
         ELSE ltrim(p.cconvo, '0') || p.dvoilib
 END AS adresse,
 CASE


### PR DESCRIPTION
Corrects the concatenation of fields for creating the full address. In some cases, the street type was concatenated to the street name without a space.


