### PR TITLE
[Bugfix] get_available_majic_files: file_regex en majuscule comme le nom de fichier

### DIFF
--- a/cadastre/cadastre_import.py
+++ b/cadastre/cadastre_import.py
@@ -533,6 +533,8 @@ class cadastreImport(QObject):
                 URL_TOPO,
                 URL_TOPO,
             )
+            self.qc.updateLog(msg)
+            self.go = False
 
             return False
 


### PR DESCRIPTION
Le nom de fichier est passé en majuscule mais la regex ne l'était pas.

Funded by Conseil Départemental du vaucluse
