### PR TITLE
add space in dlign4 when needed

### DIFF
--- a/cadastre/scripts/plugin/2025/majic3_formatage_donnees.sql
+++ b/cadastre/scripts/plugin/2025/majic3_formatage_donnees.sql
@@ -792,7 +792,7 @@ SELECT DISTINCT ON (ccodep,ccocom,dnupro,dnulp,dnuper)
   CASE WHEN trim(SUBSTRING(tmp,119,1))='' THEN NULL ELSE trim(SUBSTRING(tmp,119,1)) END AS gtyp5,
   CASE WHEN trim(SUBSTRING(tmp,120,1))='' THEN NULL ELSE trim(SUBSTRING(tmp,120,1)) END AS gtyp6,
   SUBSTRING(tmp,121,30) AS dlign3,
-  CASE WHEN REGEXP('[0-9]{4}[A-Z]',SUBSTRING(tmp,151,5)) THEN SUBSTRING(tmp,151,4) || ' ' || SUBSTRING(tmp,155,1) || ' ' || SUBSTRING(tmp,156,31) ELSE SUBSTRING(tmp,151,36) END AS dlign4,
+  CASE WHEN SUBSTRING(tmp,151,5) ~ '[0-9]{4}[A-Z]' THEN SUBSTRING(tmp,151,4) || ' ' || SUBSTRING(tmp,155,1) || ' ' || SUBSTRING(tmp,156,31) ELSE SUBSTRING(tmp,151,36) END AS dlign4,
   CASE WHEN trim(SUBSTRING(tmp,249,1))='' THEN '                              ' ELSE SUBSTRING(tmp,187,30) END AS dlign5,
   SUBSTRING(tmp,217,32) AS dlign6,
   SUBSTRING(tmp,249,3) AS ccopay,

--- a/cadastre/scripts/plugin/2025/majic3_formatage_donnees.sql
+++ b/cadastre/scripts/plugin/2025/majic3_formatage_donnees.sql
@@ -792,7 +792,7 @@ SELECT DISTINCT ON (ccodep,ccocom,dnupro,dnulp,dnuper)
   CASE WHEN trim(SUBSTRING(tmp,119,1))='' THEN NULL ELSE trim(SUBSTRING(tmp,119,1)) END AS gtyp5,
   CASE WHEN trim(SUBSTRING(tmp,120,1))='' THEN NULL ELSE trim(SUBSTRING(tmp,120,1)) END AS gtyp6,
   SUBSTRING(tmp,121,30) AS dlign3,
-  SUBSTRING(tmp,151,36) AS dlign4,
+  CASE WHEN REGEXP('[0-9]{4}[A-Z]',SUBSTRING(tmp,151,5)) THEN SUBSTRING(tmp,151,4) || ' ' || SUBSTRING(tmp,155,1) || ' ' || SUBSTRING(tmp,156,31) ELSE SUBSTRING(tmp,151,36) END AS dlign4,
   CASE WHEN trim(SUBSTRING(tmp,249,1))='' THEN '                              ' ELSE SUBSTRING(tmp,187,30) END AS dlign5,
   SUBSTRING(tmp,217,32) AS dlign6,
   SUBSTRING(tmp,249,3) AS ccopay,


### PR DESCRIPTION
fix #545 

Ajout d'espace autour du complément d'adresse quand l'adresse commence par 4 chiffres puis une lettre sans espace.

Fonctionne en SQLite, à voir si la fonction REGEXP est gérée avec PostgreSQL

[edit] les tests semblent suggérer que REGEXP ne fonctionne pas avec PostgreSQL, je vais voir si je trouve une solution alternative

[re-edit] A priori, j'ai trouvé une solution qui convient !
