### PR TITLE
ajout du support Topo 2026

### DIFF
--- a/cadastre/scripts/plugin/2025/majic3_formatage_donnees.sql
+++ b/cadastre/scripts/plugin/2025/majic3_formatage_donnees.sql
@@ -1,6 +1,20 @@
 -- FORMATAGE DONNEES : DEBUT
 BEGIN;
 
+-- Traitement: topo
+UPDATE ${PREFIXE}topo
+  SET code_topo=code_pays || code_region || code_dep || CASE WHEN trim(code_commune)='' THEN '   ' ELSE code_commune END || CASE WHEN trim(code_voie)='' THEN '    ' ELSE code_voie END || code_type_topo
+  WHERE code_topo IS NULL;
+
+UPDATE ${PREFIXE}topo
+  SET code_pays=SUBSTRING(code_topo,0,6),
+      code_region=SUBSTRING(code_topo,6,2),
+      code_dep=SUBSTRING(code_topo,8,2),
+      code_commune=SUBSTRING(code_topo,10,3),
+      code_voie=SUBSTRING(code_topo,13,4),
+      code_type_topo=SUBSTRING(code_topo,17,2)
+  WHERE code_pays IS NULL;
+
 -- Traitement: parcelle
 INSERT INTO ${PREFIXE}parcelle
 (

--- a/cadastre/scripts/plugin/commun_create_metier.sql
+++ b/cadastre/scripts/plugin/commun_create_metier.sql
@@ -7,6 +7,12 @@ CREATE TABLE prop (tmp text);
 CREATE TABLE topo (
     ogc_fid serial,
     code_topo character varying,
+    code_pays character varying,
+    code_region character varying,
+    code_dep character varying,
+    code_commune character varying,
+    code_voie character varying,
+    code_type_topo character varying,
     nature_de_voie character varying,
     libelle character varying,
     type_commune_actuel_r_ou_n character varying,


### PR DESCRIPTION
<!-- Add "fix" in front of # if it fixes the ticket or do nothing to only mention it -->
* Ticket : fix #577 
* reste a voir si on fait le sql pour remplir les champs, eg dans les `majic3_formatage_donnees.sql` je proposerais:
```
--- remplit le champ code_topo a partir des 6 champs de TOPO 2026
UPDATE topo SET code_topo=code_pays || code_region || code_dep || CASE WHEN trim(code_commune)='' THEN '   ' ELSE code_commune END  || CASE WHEN trim(code_voie)='' THEN '    ' ELSE code_voie END || code_type_topo WHERE code_topo IS NULL;
--- remplit les 6 champs de TOPO 2026 en splittant le champ code_topo de TOPO 2025
UPDATE topo SET code_pays=SUBSTRING(code_topo,0,6),
code_region=SUBSTRING(code_topo,6,2), code_dep=SUBSTRING(code_topo,8,2) , 
code_commune=SUBSTRING(code_topo,10,3),code_voie=SUBSTRING(code_topo,13,4), 
code_type_topo=SUBSTRING(code_topo,17,2) WHERE code_pays IS NULL;
```

je vais faire qqs tests avec spatialite et des données 2025, et topo 2025/2026 pour voir.

@mdouchin ? @dmarteau ?