### PR TITLE
add space in dlign4 when needed

### DIFF
--- a/cadastre/cadastre_import.py
+++ b/cadastre/cadastre_import.py
@@ -1306,7 +1306,7 @@ class cadastreImport(QObject):
                         self.qc.updateLog('  - %s' % comment.strip(' \n\r\t'))
 
                     # Do nothing if sql is only comment
-                    if not r.search(sqla) or not len(sqla.split('~')) == 1:
+                    if not r.search(sqla) or sqla.startswith('--~'):
                         continue
 
                     # Get SQL query

--- a/cadastre/scripts/plugin/2025/majic3_formatage_donnees.sql
+++ b/cadastre/scripts/plugin/2025/majic3_formatage_donnees.sql
@@ -792,7 +792,7 @@ SELECT DISTINCT ON (ccodep,ccocom,dnupro,dnulp,dnuper)
   CASE WHEN trim(SUBSTRING(tmp,119,1))='' THEN NULL ELSE trim(SUBSTRING(tmp,119,1)) END AS gtyp5,
   CASE WHEN trim(SUBSTRING(tmp,120,1))='' THEN NULL ELSE trim(SUBSTRING(tmp,120,1)) END AS gtyp6,
   SUBSTRING(tmp,121,30) AS dlign3,
-  CASE WHEN REGEXP('[0-9]{4}[A-Z]',SUBSTRING(tmp,151,5)) THEN SUBSTRING(tmp,151,4) || ' ' || SUBSTRING(tmp,155,1) || ' ' || SUBSTRING(tmp,156,31) ELSE SUBSTRING(tmp,151,36) END AS dlign4,
+  CASE WHEN SUBSTRING(tmp,151,5) ~ '[0-9]{4}[A-Z]' THEN SUBSTRING(tmp,151,4) || ' ' || SUBSTRING(tmp,155,1) || ' ' || SUBSTRING(tmp,156,31) ELSE SUBSTRING(tmp,151,36) END AS dlign4,
   CASE WHEN trim(SUBSTRING(tmp,249,1))='' THEN '                              ' ELSE SUBSTRING(tmp,187,30) END AS dlign5,
   SUBSTRING(tmp,217,32) AS dlign6,
   SUBSTRING(tmp,249,3) AS ccopay,

--- a/cadastre/scripts/plugin/2025/majic3_formatage_donnees.sql
+++ b/cadastre/scripts/plugin/2025/majic3_formatage_donnees.sql
@@ -792,7 +792,7 @@ SELECT DISTINCT ON (ccodep,ccocom,dnupro,dnulp,dnuper)
   CASE WHEN trim(SUBSTRING(tmp,119,1))='' THEN NULL ELSE trim(SUBSTRING(tmp,119,1)) END AS gtyp5,
   CASE WHEN trim(SUBSTRING(tmp,120,1))='' THEN NULL ELSE trim(SUBSTRING(tmp,120,1)) END AS gtyp6,
   SUBSTRING(tmp,121,30) AS dlign3,
-  SUBSTRING(tmp,151,36) AS dlign4,
+  CASE WHEN REGEXP('[0-9]{4}[A-Z]',SUBSTRING(tmp,151,5)) THEN SUBSTRING(tmp,151,4) || ' ' || SUBSTRING(tmp,155,1) || ' ' || SUBSTRING(tmp,156,31) ELSE SUBSTRING(tmp,151,36) END AS dlign4,
   CASE WHEN trim(SUBSTRING(tmp,249,1))='' THEN '                              ' ELSE SUBSTRING(tmp,187,30) END AS dlign5,
   SUBSTRING(tmp,217,32) AS dlign6,
   SUBSTRING(tmp,249,3) AS ccopay,

--- a/cadastre/scripts/plugin/2025/majic3_formatage_donnees.sql
+++ b/cadastre/scripts/plugin/2025/majic3_formatage_donnees.sql
@@ -793,13 +793,13 @@ SELECT DISTINCT ON (ccodep,ccocom,dnupro,dnulp,dnuper)
   CASE WHEN trim(SUBSTRING(tmp,120,1))='' THEN NULL ELSE trim(SUBSTRING(tmp,120,1)) END AS gtyp6,
   SUBSTRING(tmp,121,30) AS dlign3,
   CASE WHEN SUBSTRING(tmp,151,5) ~ '[0-9]{4}[A-Z]' THEN
-      CASE WHEN SUBSTRING(tmp,151,10) ~ '[0-9]{4}[A-Z]{6}' AND SUBSTRING(tmp,156,4) IN (SELECT natvoi FROM natvoi) THEN
+      CASE WHEN SUBSTRING(tmp,151,10) ~ '[0-9]{4}[A-Z]{6}' AND SUBSTRING(tmp,156,4) IN (SELECT natvoi FROM ${PREFIXE}natvoi) THEN
           SUBSTRING(tmp,151,4) || ' ' || SUBSTRING(tmp,155,1) || ' ' || SUBSTRING(tmp,156,4) || ' ' || SUBSTRING(tmp,160,27)
       ELSE
           SUBSTRING(tmp,151,4) || ' ' || SUBSTRING(tmp,155,1) || ' ' || SUBSTRING(tmp,156,31)
       END
   ELSE
-      CASE WHEN SUBSTRING(tmp,151,10) ~ '[0-9]{4}.[A-Z]{5}' AND SUBSTRING(tmp,156,4) IN (SELECT natvoi FROM natvoi) THEN
+      CASE WHEN SUBSTRING(tmp,151,10) ~ '[0-9]{4}.[A-Z]{5}' AND SUBSTRING(tmp,156,4) IN (SELECT natvoi FROM ${PREFIXE}natvoi) THEN
           SUBSTRING(tmp,151,9) || ' ' || SUBSTRING(tmp,160,27)
       ELSE
           SUBSTRING(tmp,151,36)

--- a/cadastre/scripts/plugin/2025/majic3_formatage_donnees.sql
+++ b/cadastre/scripts/plugin/2025/majic3_formatage_donnees.sql
@@ -792,7 +792,19 @@ SELECT DISTINCT ON (ccodep,ccocom,dnupro,dnulp,dnuper)
   CASE WHEN trim(SUBSTRING(tmp,119,1))='' THEN NULL ELSE trim(SUBSTRING(tmp,119,1)) END AS gtyp5,
   CASE WHEN trim(SUBSTRING(tmp,120,1))='' THEN NULL ELSE trim(SUBSTRING(tmp,120,1)) END AS gtyp6,
   SUBSTRING(tmp,121,30) AS dlign3,
-  CASE WHEN SUBSTRING(tmp,151,5) ~ '[0-9]{4}[A-Z]' THEN SUBSTRING(tmp,151,4) || ' ' || SUBSTRING(tmp,155,1) || ' ' || SUBSTRING(tmp,156,31) ELSE SUBSTRING(tmp,151,36) END AS dlign4,
+  CASE WHEN SUBSTRING(tmp,151,5) ~ '[0-9]{4}[A-Z]' THEN
+      CASE WHEN SUBSTRING(tmp,151,10) ~ '[0-9]{4}[A-Z]{6}' AND SUBSTRING(tmp,156,4) IN (SELECT natvoi FROM natvoi) THEN
+          SUBSTRING(tmp,151,4) || ' ' || SUBSTRING(tmp,155,1) || ' ' || SUBSTRING(tmp,156,4) || ' ' || SUBSTRING(tmp,160,27)
+      ELSE
+          SUBSTRING(tmp,151,4) || ' ' || SUBSTRING(tmp,155,1) || ' ' || SUBSTRING(tmp,156,31)
+      END
+  ELSE
+      CASE WHEN SUBSTRING(tmp,151,10) ~ '[0-9]{4}.[A-Z]{5}' AND SUBSTRING(tmp,156,4) IN (SELECT natvoi FROM natvoi) THEN
+          SUBSTRING(tmp,151,9) || ' ' || SUBSTRING(tmp,160,27)
+      ELSE
+          SUBSTRING(tmp,151,36)
+      END
+  END AS dlign4,
   CASE WHEN trim(SUBSTRING(tmp,249,1))='' THEN '                              ' ELSE SUBSTRING(tmp,187,30) END AS dlign5,
   SUBSTRING(tmp,217,32) AS dlign6,
   SUBSTRING(tmp,249,3) AS ccopay,


### PR DESCRIPTION
<!-- Add "fix" in front of # if it fixes the ticket or do nothing to only mention it -->
* Ticket : fix #545

builds on top of #546 from @ThT12 and add a space after `natvoi` when it is 4 chars, eg
- before:
```
0022BRUE DE BOYER
0035TQUAIVOLTAIRE
0015 CITEDES COMBES
0000 CITECAZEAU BP56
```

- after:
```
0022 B RUE DE BOYER
0035 T QUAI VOLTAIRE
0015 CITE DES COMBES
0000 CITE CAZEAU BP56
```

tested on 146801 entries from the `proprietaires` sqlite table for 72 communes in dept 43 (eg agglo du puy en velay)

@mdouchin can you test/merge ? i'll triplecheck that it also gives the same result on postgis/postgresql.